### PR TITLE
Add migration plans for remaining COBOL batch programs

### DIFF
--- a/docs/migration/CBACT02C-to-java-plan.md
+++ b/docs/migration/CBACT02C-to-java-plan.md
@@ -1,0 +1,297 @@
+# Migration Plan: `CBACT02C.cbl` → Java
+
+**Source program:** `app/cbl/CBACT02C.cbl` — the **card master file processor** of CardDemo. Driven by `app/jcl/READCARD.jcl`. Sequentially reads `CARDFILE` (KSDS, 150-byte records) and `DISPLAY`s every record to `SYSOUT`.
+
+**Target location (mandatory):** `app/java/batch_processing_workflow/`
+
+**Goal:** A Java port that produces a SYSOUT capture **byte-for-byte identical** to the COBOL `DISPLAY` output on the same input fixture, verified by an automated test that diffs against a GnuCOBOL-runnable reference build.
+
+This plan is purely a plan. **No code is written until approved.**
+
+---
+
+## 1. Source contract — what `CBACT02C` does
+
+### 1.1 Inputs
+
+| DD name | COBOL `SELECT` | Org / Access | Record (copybook) | Notes |
+| ------- | -------------- | ------------ | ----------------- | ----- |
+| `CARDFILE` | `CARDFILE-FILE` | INDEXED / SEQUENTIAL | 150 bytes (`CVACT02Y` — `CARD-RECORD`) | Driving file. Walked sequentially in key order. |
+
+### 1.2 Outputs
+
+| Stream | COBOL verb | Format | Notes |
+| ------ | ---------- | ------ | ----- |
+| `SYSOUT` | `DISPLAY CARD-RECORD` | One COBOL `DISPLAY` line per input record | Trailing newline added by COBOL `DISPLAY`. Plus boilerplate `START` / `END` banners and any error-path lines. |
+
+There is **no file output**. The acceptance check is the SYSOUT capture.
+
+### 1.3 Algorithm (paragraph map)
+
+```
+PROCEDURE DIVISION:
+    DISPLAY 'START OF EXECUTION OF PROGRAM CBACT02C'
+    PERFORM 0000-CARDFILE-OPEN              — OPEN INPUT CARDFILE-FILE; ABEND on non-'00'
+
+    LOOP UNTIL END-OF-FILE = 'Y':
+        PERFORM 1000-CARDFILE-GET-NEXT
+            READ CARDFILE-FILE INTO CARD-RECORD
+            status '00': MOVE 0 TO APPL-RESULT
+            status '10' (EOF): MOVE 16 TO APPL-RESULT
+            other status: MOVE 12 → ABEND via 9999-ABEND-PROGRAM
+            APPL-EOF (16) → MOVE 'Y' TO END-OF-FILE
+        IF END-OF-FILE = 'N': DISPLAY CARD-RECORD
+
+    PERFORM 9000-CARDFILE-CLOSE             — CLOSE CARDFILE-FILE; ABEND on non-'00'
+    DISPLAY 'END OF EXECUTION OF PROGRAM CBACT02C'
+    GOBACK
+```
+
+### 1.4 Record layout — `CARD-RECORD` (`CVACT02Y`, 150 bytes)
+
+| Offset | Len | COBOL name | PIC | Storage | Java type |
+| ------ | --- | ---------- | --- | ------- | --------- |
+| 0 | 16 | `CARD-NUM` | `PIC X(16)` | text (primary key) | `String` |
+| 16 | 11 | `CARD-ACCT-ID` | `PIC 9(11)` | unsigned numeric | `long` |
+| 27 | 3 | `CARD-CVV-CD` | `PIC 9(03)` | unsigned numeric | `int` |
+| 30 | 50 | `CARD-EMBOSSED-NAME` | `PIC X(50)` | text | `String` |
+| 80 | 10 | `CARD-EXPIRAION-DATE` | `PIC X(10)` | text | `String` |
+| 90 | 1 | `CARD-ACTIVE-STATUS` | `PIC X(01)` | text | `String` |
+| 91 | 59 | `FILLER` | `PIC X(59)` | spaces | n/a (preserve raw bytes) |
+
+**Total: 150 bytes** — matches JCL `LRECL=150`. No signed fields, no zoned-decimal sign overpunch, no packed decimal. The simplest record in the catalog.
+
+### 1.5 SYSOUT format — what `DISPLAY CARD-RECORD` actually emits
+
+COBOL `DISPLAY` of a level-01 group emits the underlying byte buffer with no formatting, then appends a newline. For `CARD-RECORD` this means:
+
+```
+<16 bytes CARD-NUM><11 digits CARD-ACCT-ID><3 digits CARD-CVV-CD><50 bytes CARD-EMBOSSED-NAME><10 bytes CARD-EXPIRAION-DATE><1 byte CARD-ACTIVE-STATUS><59 bytes spaces>\n
+```
+
+Total per line: **151 bytes** (150 record bytes + newline). Plus two banner lines:
+
+```
+START OF EXECUTION OF PROGRAM CBACT02C\n
+... 150-byte CARD-RECORD lines, one per record ...
+END OF EXECUTION OF PROGRAM CBACT02C\n
+```
+
+The `END-OF-FILE = 'N'` guard inside `1000-CARDFILE-GET-NEXT` and the outer mainline loop together mean: **on the read that returns status `'10'`, no `DISPLAY` happens**. Only successful reads emit a record line. The Java port must replicate this — emitting one extra blank line on EOF is a regression.
+
+---
+
+## 2. Equivalence requirements (acceptance criteria)
+
+One artifact must match byte-for-byte between the COBOL run and the Java run on the same input fixture:
+
+1. **`SYSOUT` capture** — every byte of the captured stdout. Includes:
+   - The `START` banner.
+   - One 150-byte record line + `\n` per input record.
+   - The `END` banner.
+
+**Acceptance test:** `diff -q sysout.cobol.txt sysout.java.txt` returns silently.
+
+**No timestamp injection needed.** `CBACT02C` calls neither `FUNCTION CURRENT-DATE` nor any DB2 timestamp builder; SYSOUT is fully deterministic from the fixture.
+
+---
+
+## 3. Target architecture
+
+### 3.1 Layout
+
+```
+app/java/batch_processing_workflow/
+└── src/
+    ├── main/java/com/carddemo/batch/
+    │   ├── card/                                       ← new subpackage for CBACT02C
+    │   │   ├── CardFileProcessor.java                  main(); mirrors PROCEDURE DIVISION
+    │   │   ├── domain/
+    │   │   │   └── CardRecord.java                     wraps CVACT02Y (150 bytes)
+    │   │   └── io/
+    │   │       └── CardFileReader.java                 sequential 150-byte reader
+    │   ├── interest/                                   ← UNCHANGED
+    │   └── account/                                    ← from CBACT01C plan, UNCHANGED
+    └── test/java/com/carddemo/batch/card/
+        ├── CardRecordRoundTripTest.java
+        ├── CardFileProcessorTest.java
+        └── CardFileGoldenFileEquivalenceIT.java
+```
+
+**Reused unchanged:**
+
+| Class | Source package | Reuse purpose |
+| ----- | -------------- | ------------- |
+| `FixedWidthFormat` | `interest.io` | `text()`, `unsignedNumeric()` for record parsing |
+| `BatchAbendException` | `interest.util` | ABEND path |
+
+> **Package-debt note.** This is the third batch program to depend on
+> `interest.io.FixedWidthFormat` and `interest.util.BatchAbendException`.
+> Per the plan in `CBACT01C-to-java-plan.md` §3.1, this is the right
+> moment to promote them into shared `com.carddemo.batch.io` /
+> `.util` packages. **Recommend adding the promotion as step 0 of
+> this plan.**
+
+### 3.2 Decisions
+
+| Decision | Default | Why |
+| -------- | ------- | --- |
+| Java version | **Java 17** | Same module |
+| SYSOUT capture mechanism | **Redirect `System.out` to a `PrintStream` over `Files.newOutputStream(...)` in `main()`** | Simplest deterministic capture; byte-identical to a shell `> sysout.java.txt` redirect |
+| Line terminator | **`\n`** (single byte, ASCII LF) | Matches GnuCOBOL `DISPLAY` default on Linux; matches the existing `interest/` test fixtures |
+| Reader strategy | **Pure sequential** — no Map, no random read | Matches `CARDFILE-FILE` `ACCESS MODE IS SEQUENTIAL` |
+
+### 3.3 Why a sequential-file GnuCOBOL port
+
+`CBACT02C.cbl` declares `CARDFILE-FILE` as `INDEXED SEQUENTIAL` — a KSDS in production. The portable oracle (`CBACT02P.cbl`) changes this to `LINE SEQUENTIAL INPUT` so GnuCOBOL can read the ASCII fixture without Berkeley DB. **All `DISPLAY`, OPEN, READ, CLOSE, and ABEND paragraphs are copied verbatim** — the only edit is the `SELECT` clause.
+
+---
+
+## 4. Step-by-step migration steps
+
+| # | Step | Acceptance |
+| - | ---- | ---------- |
+| 0 | (Optional but recommended) Promote `FixedWidthFormat` and `BatchAbendException` from `interest.io`/`.util` to shared `com.carddemo.batch.io`/`.util`. Update existing `interest` and `account` callers to import from the new location. | `mvn test` passes for all existing tests with no behavioural change |
+| 1 | Define `CardRecord` (150-byte wrapper; six typed accessors + `rawBytes()`). | Round-trip test parses `carddata.txt`, re-emits, byte-identical |
+| 2 | Implement `CardFileReader` (sequential 150-byte reader, ISO-8859-1, pads short input lines to 150). | Reads fixture; record count matches `wc -c / 150` |
+| 3 | Implement `CardFileProcessor.main()` — opens a `PrintStream` to a configurable target (default `System.out`), emits banners, loops over reader, writes `record.rawBytes()` + `\n` per record. | Runs end-to-end on fixtures; output is non-empty |
+| 4 | Write `cobol-reference/CBACT02P.cbl` (sequential-only portable oracle: `INDEXED SEQUENTIAL` → `LINE SEQUENTIAL INPUT`; everything else verbatim) plus the matching `tools/build.sh` and `tools/run.sh` patches. | `bash regen-golden.sh` produces `fixtures/expected/sysout.txt` |
+| 5 | Extend `cobol-reference/tools/regen-golden.sh` to build, run, and capture `CBACT02P` SYSOUT to `fixtures/expected/sysout.txt`. | Output captured |
+| 6 | Write `CardRecordRoundTripTest`, `CardFileProcessorTest` (smoke), and `CardFileGoldenFileEquivalenceIT`. | All pass |
+| 7 | Update `docs/cobol/batch-programs.md` `CBACT02C` section with pointer to this plan and the Java port. | Pointer added |
+
+**Estimated effort:** ~4–6 hours. Less work than `CBACT01C` (no COMP-3, no `OCCURS`, no `COBDATFT`, no VBR splitting).
+
+---
+
+## 5. Logic equivalency safeguards
+
+### 5.1 EOF means "no display"
+
+In COBOL the loop body is:
+
+```cobol
+PERFORM 1000-CARDFILE-GET-NEXT
+IF END-OF-FILE = 'N'
+    DISPLAY CARD-RECORD
+END-IF
+```
+
+So on the read that returns status `'10'`, the read sets `END-OF-FILE = 'Y'` *inside* `1000-CARDFILE-GET-NEXT` (via `APPL-EOF`), and the outer `IF` blocks the `DISPLAY`. The Java port must check the EOF flag *after* the read, before emitting:
+
+```java
+while (!eof) {
+    Optional<CardRecord> next = reader.readNext();
+    if (next.isEmpty()) { eof = true; continue; }    // EOF → no print
+    out.write(next.get().rawBytes());
+    out.write('\n');
+}
+```
+
+A test fixture with exactly one record must produce exactly one record line + the two banners — three lines total, not four.
+
+### 5.2 Trailing FILLER preservation
+
+`CARD-RECORD` ends in 59 bytes of `FILLER` (`PIC X(59)`). The fixture stores them as ASCII spaces. Java must preserve them on output — do not `trim()` the record before emitting. The 59 bytes are part of the COBOL `DISPLAY`'s output.
+
+### 5.3 GnuCOBOL `LINE SEQUENTIAL` strips trailing spaces on *input*
+
+This is the inverse of the well-known output-side issue. When `CBACT02P.cbl` reads `carddata.txt` with `LINE SEQUENTIAL INPUT`, GnuCOBOL pads short lines with spaces up to the FD's record length — but only if `COB_LS_FIXED=Y` is exported at run time. Without it, short lines decode as truncated records and the `DISPLAY` lines are short. **Always export `COB_LS_FIXED=Y` in `tools/run.sh`.** This is silent killer #12 from the playbook.
+
+### 5.4 `DISPLAY` newline conventions
+
+GnuCOBOL on Linux emits `\n` (LF) at the end of every `DISPLAY`. z/OS would emit a record boundary instead (no LF). The Java port matches the GnuCOBOL behaviour — single `\n` per display, no leading or trailing whitespace beyond what's in the record buffer.
+
+---
+
+## 6. Test strategy
+
+### 6.1 Unit tests
+
+| Test class | Concern |
+| ---------- | ------- |
+| `CardRecordRoundTripTest` | parse → `rawBytes()` is byte-identical for every record in `carddata.txt`; six typed accessors return expected values for a hand-picked record |
+| `CardFileReaderTest` | Reads N records from a synthetic 2-record fixture; pads short lines |
+
+### 6.2 Round-trip integration test
+
+```
+parse(fixtures/input/carddata.txt) → CardRecord[]
+records.forEach(r -> r.rawBytes()) → assert bytes == original file bytes
+```
+
+### 6.3 Golden-file integration test
+
+```
+1. cd cobol-reference && bash tools/regen-golden.sh
+   → cobc -x -free -fsign=EBCDIC CBACT02P.cbl
+   → COB_LS_FIXED=Y ./CBACT02P > fixtures/expected/sysout.txt
+2. mvn verify
+   → CardFileGoldenFileEquivalenceIT:
+       • runs CardFileProcessor.main(...) with stdout redirected to temp/sysout.txt
+       • Files.mismatch(expected/sysout.txt, temp/sysout.txt) == -1L
+```
+
+### 6.4 Synthetic edge-case fixtures
+
+| Fixture | Purpose |
+| ------- | ------- |
+| `single-card/` | 1 card record → 1 record line + 2 banners = 3 lines |
+| `empty/` | 0 records → 2 banner lines only, no record line |
+| `trailing-filler/` | Record with non-space bytes in the FILLER → bytes preserved verbatim in `DISPLAY` |
+
+---
+
+## 7. Documents to be produced during implementation
+
+1. Append a "CBACT02C — Card File Processor" section to
+   `app/java/batch_processing_workflow/README.md` (build + run command).
+2. Append a "CBACT02C" section to
+   `app/java/batch_processing_workflow/HOW-TO-TEST.md` with the
+   `regen-golden.sh` extension steps and `mvn verify` invocation.
+3. After implementation, add the architecture companion
+   `docs/migration/CBACT02C-java-architecture.md` (very small Mermaid
+   graph: `CardFileProcessor → CardFileReader → CardRecord →
+   FixedWidthFormat`).
+
+---
+
+## 8. Risks and open decisions
+
+### 8.1 Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `DISPLAY` line endings differ between GnuCOBOL and Java (`\r\n` vs `\n`) | `CardFileProcessor` writes `'\n'` literal byte; `tools/run.sh` runs the binary on Linux; `HOW-TO-TEST.md` warns Windows users |
+| GnuCOBOL strips trailing spaces from input → record short → `DISPLAY` short | `COB_LS_FIXED=Y` in `run.sh` (silent killer #12) |
+| `System.out.flush()` not called → Java IT sees a truncated capture | `CardFileProcessor` uses try-with-resources on the `PrintStream`; flushes on close |
+| Premature promotion of `FixedWidthFormat`/`BatchAbendException` could conflict with the still-being-merged `account/` package debt | Coordinate with the `CBACT01C` implementation; if `CBACT01C` lands first, this plan's step 0 is already done |
+
+### 8.2 Open decisions to confirm
+
+- **Step 0 promotion** — accept (recommended) or defer (still allowed; plan works either way).
+- **SYSOUT target** — defaulting to `System.out` for CLI runs and a configurable `Path` for tests. OK?
+- **Java version** — 17 (same module). OK?
+
+---
+
+## 9. Out of scope for this migration
+
+- Other batch programs (covered by their own plans in this directory).
+- Online (`CO*`) programs.
+- Production VSAM KSDS access — the portable oracle reads ASCII fixtures, not real VSAM clusters.
+
+---
+
+## 10. Approval gate
+
+Confirm before implementation:
+
+1. **Step 0 promotion** of `FixedWidthFormat` and `BatchAbendException`
+   to shared packages — accept or defer.
+2. **SYSOUT capture** via `System.out` redirection — accept or specify
+   a different mechanism.
+3. **Defaults** in §3.2 — accept or override.
+4. **Scope locked** to `CBACT02C` only — yes/no.
+
+Once confirmed, work proceeds through steps 0–7 in §4, one commit per step.

--- a/docs/migration/CBACT03C-to-java-plan.md
+++ b/docs/migration/CBACT03C-to-java-plan.md
@@ -1,0 +1,285 @@
+# Migration Plan: `CBACT03C.cbl` → Java
+
+**Source program:** `app/cbl/CBACT03C.cbl` — the **card-account cross-reference processor** of CardDemo. Driven by `app/jcl/READXREF.jcl`. Sequentially reads `XREFFILE` (KSDS, 50-byte records) and `DISPLAY`s every record to `SYSOUT`.
+
+**Target location (mandatory):** `app/java/batch_processing_workflow/`
+
+**Goal:** A Java port that produces a SYSOUT capture **byte-for-byte identical** to the COBOL `DISPLAY` output on the same input fixture, verified by an automated test that diffs against a GnuCOBOL-runnable reference build.
+
+This plan is purely a plan. **No code is written until approved.**
+
+---
+
+## 1. Source contract — what `CBACT03C` does
+
+### 1.1 Inputs
+
+| DD name | COBOL `SELECT` | Org / Access | Record (copybook) | Notes |
+| ------- | -------------- | ------------ | ----------------- | ----- |
+| `XREFFILE` | `XREFFILE-FILE` | INDEXED / SEQUENTIAL | 50 bytes (`CVACT03Y` — `CARD-XREF-RECORD`) | Driving file. Walked sequentially in key order. |
+
+### 1.2 Outputs
+
+| Stream | COBOL verb | Format |
+| ------ | ---------- | ------ |
+| `SYSOUT` | `DISPLAY CARD-XREF-RECORD` | One COBOL `DISPLAY` line per input record + two banners |
+
+No file output; SYSOUT capture is the only artifact.
+
+### 1.3 Algorithm (paragraph map)
+
+```
+PROCEDURE DIVISION:
+    DISPLAY 'START OF EXECUTION OF PROGRAM CBACT03C'
+    PERFORM 0000-XREFFILE-OPEN              — OPEN INPUT XREFFILE-FILE; ABEND on non-'00'
+
+    LOOP UNTIL END-OF-FILE = 'Y':
+        PERFORM 1000-XREFFILE-GET-NEXT
+            READ XREFFILE-FILE INTO CARD-XREF-RECORD
+            status '00': MOVE 0 TO APPL-RESULT, DISPLAY CARD-XREF-RECORD   ← duplicate-display bug
+            status '10' (EOF): MOVE 16 TO APPL-RESULT
+            other: ABEND
+            APPL-EOF (16) → MOVE 'Y' TO END-OF-FILE
+        IF END-OF-FILE = 'N': DISPLAY CARD-XREF-RECORD                       ← second display
+
+    PERFORM 9000-XREFFILE-CLOSE
+    DISPLAY 'END OF EXECUTION OF PROGRAM CBACT03C'
+    GOBACK
+```
+
+**Notable quirk:** `CBACT03C` `DISPLAY`s the record **twice** — once inside `1000-XREFFILE-GET-NEXT` (status `'00'` branch) and once in the mainline `IF END-OF-FILE = 'N'`. This is the canonical example of the duplicate-display pattern noted in `docs/cobol/batch-programs.md` for `CBACT03C` and `CBCUS01C`. **The Java port must replicate it.** SYSOUT will have two consecutive identical lines per record.
+
+### 1.4 Record layout — `CARD-XREF-RECORD` (`CVACT03Y`, 50 bytes)
+
+| Offset | Len | COBOL name | PIC | Storage | Java type |
+| ------ | --- | ---------- | --- | ------- | --------- |
+| 0 | 16 | `XREF-CARD-NUM` | `PIC X(16)` | text (primary key) | `String` |
+| 16 | 11 | `XREF-CUST-ID` | `PIC 9(11)` | unsigned numeric | `long` |
+| 27 | 11 | `XREF-ACCT-ID` | `PIC 9(11)` | unsigned numeric | `long` |
+| 38 | 12 | `FILLER` | `PIC X(12)` | spaces | n/a (preserve raw bytes) |
+
+**Total: 50 bytes** — matches JCL `LRECL=50`. No signed fields. Identical structural simplicity to `CBACT02C`. The xref record is also used by `CBACT04C` (where it is read via the `XREF-ACCT-ID` AIX); the `interest/` Java port already has `CardXrefRecord` for that purpose.
+
+### 1.5 SYSOUT format
+
+Each `DISPLAY CARD-XREF-RECORD` emits the 50-byte buffer + `\n` (51 bytes per line). With the duplicate-display, each input record produces **two** consecutive identical lines. Plus two banners.
+
+For a fixture of N input records, expected SYSOUT:
+
+```
+START OF EXECUTION OF PROGRAM CBACT03C\n
+<50 bytes record 1>\n        ← from inside 1000-…-GET-NEXT
+<50 bytes record 1>\n        ← from mainline IF
+<50 bytes record 2>\n
+<50 bytes record 2>\n
+…
+END OF EXECUTION OF PROGRAM CBACT03C\n
+```
+
+Total lines: `2 + 2*N`.
+
+---
+
+## 2. Equivalence requirements (acceptance criteria)
+
+1. **`SYSOUT` capture** matches byte-for-byte. The duplicate-display means twice as many record lines as input records.
+
+**Acceptance test:** `diff -q sysout.cobol.txt sysout.java.txt` returns silently.
+
+**No timestamp injection needed.**
+
+---
+
+## 3. Target architecture
+
+### 3.1 Layout
+
+```
+app/java/batch_processing_workflow/
+└── src/
+    ├── main/java/com/carddemo/batch/
+    │   ├── xref/                                       ← new subpackage for CBACT03C
+    │   │   ├── XrefFileProcessor.java                  main(); mirrors PROCEDURE DIVISION
+    │   │   └── io/
+    │   │       └── XrefFileReader.java                 sequential 50-byte reader
+    │   ├── interest/                                   ← UNCHANGED; already has CardXrefRecord
+    │   ├── account/                                    ← UNCHANGED
+    │   └── card/                                       ← from CBACT02C plan, UNCHANGED
+    └── test/java/com/carddemo/batch/xref/
+        ├── XrefFileProcessorTest.java
+        └── XrefFileGoldenFileEquivalenceIT.java
+```
+
+**Reused unchanged:**
+
+| Class | Source package | Reuse purpose |
+| ----- | -------------- | ------------- |
+| `CardXrefRecord` | `interest.domain` | Already wraps `CVACT03Y` (50 bytes); usable as-is |
+| `FixedWidthFormat` | shared `io` (post-promotion) | Record parsing |
+| `BatchAbendException` | shared `util` (post-promotion) | ABEND path |
+
+> **No new domain class needed.** This is the first migration to fully
+> reuse a domain record from a previous port (`interest.domain.CardXrefRecord`
+> introduced for `CBACT04C`'s AIX lookup). Validates the package debt
+> argument: shared records belong in a shared package once they have
+> two callers.
+
+### 3.2 Decisions
+
+| Decision | Default | Why |
+| -------- | ------- | --- |
+| Java version | **Java 17** | Same module |
+| SYSOUT capture | **`System.out` redirection (same pattern as CBACT02C plan)** | Consistency across reader-style ports |
+| Reader strategy | **Pure sequential** | Matches `XREFFILE-FILE` `ACCESS MODE IS SEQUENTIAL` |
+| Domain record | **Reuse `interest.domain.CardXrefRecord`** | Already wraps the same copybook |
+
+### 3.3 Why a sequential-file GnuCOBOL port
+
+Same pattern as `CBACT02C`: change the `SELECT` from `INDEXED SEQUENTIAL` to `LINE SEQUENTIAL INPUT` in the portable oracle (`CBACT03P.cbl`); copy every other line verbatim. The duplicate-`DISPLAY` lines are preserved as-is in the oracle.
+
+---
+
+## 4. Step-by-step migration steps
+
+| # | Step | Acceptance |
+| - | ---- | ---------- |
+| 1 | Implement `XrefFileReader` (sequential 50-byte reader; emits `CardXrefRecord` from `interest.domain`). | Reads `cardxref.txt` fixture; record count matches `wc -c / 50` |
+| 2 | Implement `XrefFileProcessor.main()` — banners + dual-write loop + close + final banner. The dual-write replicates the COBOL duplicate-display. | Runs end-to-end on fixtures; output line count = 2 + 2*record_count |
+| 3 | Write `cobol-reference/CBACT03P.cbl` (sequential-only oracle; one-line `SELECT` change vs `CBACT03C.cbl`). | Compiles; runs |
+| 4 | Extend `cobol-reference/tools/regen-golden.sh` to capture `CBACT03P` SYSOUT to `fixtures/expected/sysout.txt`. | Output captured |
+| 5 | Write `XrefFileProcessorTest` (smoke + line-count check) and `XrefFileGoldenFileEquivalenceIT`. | All pass |
+| 6 | Update `docs/cobol/batch-programs.md` `CBACT03C` section with pointer to this plan. | Pointer added |
+
+**Estimated effort:** ~3–4 hours. Smaller than `CBACT02C` because no new domain class is introduced (full reuse of `CardXrefRecord`).
+
+---
+
+## 5. Logic equivalency safeguards
+
+### 5.1 Duplicate-display fidelity
+
+This is the central correctness concern. The Java mainline must emit each record **twice**, mirroring:
+
+```cobol
+PERFORM 1000-XREFFILE-GET-NEXT          ← if status='00', this DISPLAYs once
+IF END-OF-FILE = 'N'
+    DISPLAY CARD-XREF-RECORD            ← then mainline DISPLAYs again
+END-IF
+```
+
+Java equivalent:
+
+```java
+while (!eof) {
+    Optional<CardXrefRecord> next = reader.readNext();
+    if (next.isEmpty()) { eof = true; continue; }
+    out.write(next.get().rawBytes());     // mirrors inner DISPLAY (status '00' branch)
+    out.write('\n');
+    out.write(next.get().rawBytes());     // mirrors mainline DISPLAY
+    out.write('\n');
+}
+```
+
+A test fixture with one record must produce exactly 4 lines (`START`, record, record, `END`), not 3.
+
+### 5.2 EOF still suppresses both displays
+
+When the read returns status `'10'`, neither display fires. The inner `DISPLAY CARD-XREF-RECORD` is in the `status = '00'` branch only, and the outer one is gated by `END-OF-FILE = 'N'`. Two-record fixture → 6 record lines (3 pairs of duplicates), not 7 or 8.
+
+### 5.3 Padding semantics
+
+The 12-byte trailing FILLER (offsets 38–49) is preserved verbatim, same as `CBACT02C`'s 59-byte FILLER.
+
+### 5.4 GnuCOBOL `LINE SEQUENTIAL` quirks
+
+Same as `CBACT02C` — `COB_LS_FIXED=Y` required at run time.
+
+---
+
+## 6. Test strategy
+
+### 6.1 Unit tests
+
+| Test class | Concern |
+| ---------- | ------- |
+| `XrefFileReaderTest` | Reads N records from a 2-record synthetic fixture; pads short lines |
+
+(`CardXrefRecord` already has its own round-trip tests in the `interest` test package — no need to duplicate.)
+
+### 6.2 Smoke test
+
+`XrefFileProcessorTest` runs the processor against a 1-record synthetic fixture and asserts the output is exactly 4 lines (`START`, record, record, `END`), each ending with `\n`, with the record line equal to the 50 input bytes.
+
+### 6.3 Golden-file integration test
+
+```
+1. cd cobol-reference && bash tools/regen-golden.sh
+   → cobc -x -free -fsign=EBCDIC CBACT03P.cbl
+   → COB_LS_FIXED=Y ./CBACT03P > fixtures/expected/sysout.txt
+2. mvn verify
+   → XrefFileGoldenFileEquivalenceIT
+       • runs XrefFileProcessor.main(...)
+       • Files.mismatch(expected/sysout.txt, temp/sysout.txt) == -1L
+```
+
+### 6.4 Synthetic edge-case fixtures
+
+| Fixture | Purpose |
+| ------- | ------- |
+| `single-xref/` | 1 record → 4 SYSOUT lines (validates duplicate-display) |
+| `empty/` | 0 records → 2 SYSOUT lines (banners only) |
+
+---
+
+## 7. Documents to be produced during implementation
+
+1. Append a "CBACT03C — Cross-Reference Processor" section to
+   `app/java/batch_processing_workflow/README.md`.
+2. Append a CBACT03C section to `HOW-TO-TEST.md`.
+3. After implementation, add the architecture companion
+   `docs/migration/CBACT03C-java-architecture.md` (small Mermaid:
+   `XrefFileProcessor → XrefFileReader → CardXrefRecord (reused from
+   interest)`).
+
+---
+
+## 8. Risks and open decisions
+
+### 8.1 Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Forgetting the duplicate-display → SYSOUT line count off by N | Smoke test asserts exact line count for a 1-record fixture; golden-file IT catches any byte-level drift |
+| Reusing `interest.domain.CardXrefRecord` couples the `xref` package to `interest` until promotion | Acceptable; either move `CardXrefRecord` to a shared `domain` package as part of this work, or accept the dep until a fourth caller emerges |
+| GnuCOBOL `LINE SEQUENTIAL` strips trailing spaces → records short → both displays short | `COB_LS_FIXED=Y` in `run.sh` |
+
+### 8.2 Open decisions to confirm
+
+- **Domain-record reuse vs. new class** — defaulting to reuse
+  `interest.domain.CardXrefRecord`. If the team prefers a new
+  `xref.domain.CrossReferenceRecord` (for symmetry with `account` and
+  `card`), flag it; the change is a one-line constructor call.
+- **Promote `CardXrefRecord` to a shared package** — recommended
+  alongside this work. Defer if the package promotion was already done
+  for `CBACT02C`.
+
+---
+
+## 9. Out of scope for this migration
+
+Same as `CBACT02C` — this plan is `CBACT03C` only.
+
+---
+
+## 10. Approval gate
+
+Confirm before implementation:
+
+1. **Reuse of `interest.domain.CardXrefRecord`** rather than a new
+   class — accept or override.
+2. **Duplicate-display fidelity** is the desired behaviour (this is a
+   faithful port of an apparent COBOL bug) — yes/no.
+3. **Defaults in §3.2** — accept or override.
+4. **Scope locked** to `CBACT03C` only — yes/no.
+
+Once confirmed, work proceeds through steps 1–6 in §4, one commit per step.

--- a/docs/migration/CBCUS01C-to-java-plan.md
+++ b/docs/migration/CBCUS01C-to-java-plan.md
@@ -1,0 +1,253 @@
+# Migration Plan: `CBCUS01C.cbl` → Java
+
+**Source program:** `app/cbl/CBCUS01C.cbl` — the **customer master file processor** of CardDemo. Driven by `app/jcl/READCUST.jcl`. Sequentially reads `CUSTFILE` (KSDS, 500-byte records) and `DISPLAY`s every record to `SYSOUT`.
+
+**Target location (mandatory):** `app/java/batch_processing_workflow/`
+
+**Goal:** A Java port that produces a SYSOUT capture **byte-for-byte identical** to the COBOL `DISPLAY` output on the same input fixture, verified by an automated test that diffs against a GnuCOBOL-runnable reference build.
+
+This plan is purely a plan. **No code is written until approved.**
+
+---
+
+## 1. Source contract — what `CBCUS01C` does
+
+### 1.1 Inputs
+
+| DD name | COBOL `SELECT` | Org / Access | Record (copybook) | Notes |
+| ------- | -------------- | ------------ | ----------------- | ----- |
+| `CUSTFILE` | `CUSTFILE-FILE` | INDEXED / SEQUENTIAL | 500 bytes (`CVCUS01Y` — `CUSTOMER-RECORD`) | Driving file. Walked sequentially in key order. |
+
+### 1.2 Outputs
+
+| Stream | COBOL verb | Format |
+| ------ | ---------- | ------ |
+| `SYSOUT` | `DISPLAY CUSTOMER-RECORD` | One COBOL `DISPLAY` line per input record + two banners + duplicate-display |
+
+### 1.3 Algorithm
+
+Identical to `CBACT02C` and `CBACT03C` — open, loop with `1000-CUSTFILE-GET-NEXT`, close. Like `CBACT03C`, the success branch `DISPLAY`s the record both **inside** the GET-NEXT paragraph and again in the **mainline** loop. Two SYSOUT lines per input record.
+
+The cosmetic difference: `CBCUS01C` renames the abend / status helpers from `9999-ABEND-PROGRAM` / `9910-DISPLAY-IO-STATUS` to `Z-ABEND-PROGRAM` / `Z-DISPLAY-IO-STATUS`. This is a label-only change with no behaviour impact.
+
+### 1.4 Record layout — `CUSTOMER-RECORD` (`CVCUS01Y`, 500 bytes)
+
+The full layout is in `app/cpy/CVCUS01Y.cpy`. A summary:
+
+| Offset (decimal) | Len | COBOL name | PIC | Notes |
+| ---------------- | --- | ---------- | --- | ----- |
+| 0 | 9 | `CUST-ID` | `PIC 9(09)` | Primary key (zoned) |
+| 9 | 25 | `CUST-FIRST-NAME` | `PIC X(25)` | text |
+| 34 | 25 | `CUST-MIDDLE-NAME` | `PIC X(25)` | text |
+| 59 | 25 | `CUST-LAST-NAME` | `PIC X(25)` | text |
+| 84 | 50 | `CUST-ADDR-LINE-1` | `PIC X(50)` | text |
+| 134 | 50 | `CUST-ADDR-LINE-2` | `PIC X(50)` | text |
+| 184 | 50 | `CUST-ADDR-LINE-3` | `PIC X(50)` | text |
+| 234 | 2 | `CUST-ADDR-STATE-CD` | `PIC X(02)` | text |
+| 236 | 3 | `CUST-ADDR-COUNTRY-CD` | `PIC X(03)` | text |
+| 239 | 10 | `CUST-ADDR-ZIP` | `PIC X(10)` | text |
+| 249 | 15 | `CUST-PHONE-NUM-1` | `PIC X(15)` | text |
+| 264 | 15 | `CUST-PHONE-NUM-2` | `PIC X(15)` | text |
+| 279 | 9 | `CUST-SSN` | `PIC 9(09)` | numeric |
+| 288 | 4 | `CUST-GOVT-ISSUED-ID-N` | `PIC X(04)` (variant) | text |
+| 292 | 10 | `CUST-DOB-YYYY-MM-DD` | `PIC X(10)` | text |
+| 302 | 10 | `CUST-EFT-ACCOUNT-ID` | `PIC X(10)` | text |
+| 312 | 1 | `CUST-PRI-CARD-HOLDER-IND` | `PIC X(01)` | flag |
+| 313 | 3 | `CUST-FICO-CREDIT-SCORE` | `PIC 9(03)` | numeric |
+| 316 | 184 | `FILLER` | `PIC X(184)` | spaces |
+
+**Total: 500 bytes** — matches JCL `LRECL=500`. No signed numerics in this record — all numeric fields are unsigned zoned.
+
+> **Important note on `CVCUS01Y` vs `CUSTREC`.** `CBSTM03A` uses an
+> alternate copybook called `CUSTREC` whose `CUST-DOB` field is named
+> `CUST-DOB-YYYYMMDD` (no dashes), with different downstream slicing.
+> **Stick with `CVCUS01Y` for this plan** — it is what `CBCUS01C` and
+> `CBTRN01C` use. The `CBSTM03A` plan covers the variant separately.
+
+### 1.5 SYSOUT format
+
+Each `DISPLAY CUSTOMER-RECORD` emits the 500-byte buffer + `\n` (501 bytes per line). With duplicate-display, each input record produces **two** consecutive identical lines. Plus two banners.
+
+For N input records, expected SYSOUT total: `2 + 2*N` lines, `~501 * 2 * N` bytes for record content alone.
+
+---
+
+## 2. Equivalence requirements (acceptance criteria)
+
+1. **`SYSOUT` capture** matches byte-for-byte. Duplicate-display semantics preserved.
+
+**Acceptance test:** `diff -q sysout.cobol.txt sysout.java.txt` returns silently.
+
+**No timestamp injection needed.**
+
+---
+
+## 3. Target architecture
+
+### 3.1 Layout
+
+```
+app/java/batch_processing_workflow/
+└── src/
+    ├── main/java/com/carddemo/batch/
+    │   ├── customer/                                   ← new subpackage for CBCUS01C
+    │   │   ├── CustomerFileProcessor.java              main(); mirrors PROCEDURE DIVISION
+    │   │   ├── domain/
+    │   │   │   └── CustomerRecord.java                 wraps CVCUS01Y (500 bytes)
+    │   │   └── io/
+    │   │       └── CustomerFileReader.java             sequential 500-byte reader
+    │   ├── interest/                                   ← UNCHANGED
+    │   ├── account/                                    ← UNCHANGED
+    │   ├── card/                                       ← UNCHANGED
+    │   └── xref/                                       ← UNCHANGED
+    └── test/java/com/carddemo/batch/customer/
+        ├── CustomerRecordRoundTripTest.java
+        ├── CustomerFileProcessorTest.java
+        └── CustomerFileGoldenFileEquivalenceIT.java
+```
+
+**Reused unchanged:**
+
+| Class | Source package | Reuse purpose |
+| ----- | -------------- | ------------- |
+| `FixedWidthFormat` | shared `io` (post-promotion) | Record parsing |
+| `BatchAbendException` | shared `util` (post-promotion) | ABEND path |
+
+### 3.2 Decisions
+
+| Decision | Default | Why |
+| -------- | ------- | --- |
+| Java version | **Java 17** | Same module |
+| SYSOUT capture | **`System.out` redirection** | Same pattern as CBACT02C / CBACT03C |
+| Domain record | **New `CustomerRecord`** in `customer.domain` | First migration to handle `CVCUS01Y` directly; this class becomes reusable for `CBTRN01C` and `CBEXPORT`/`CBIMPORT` plans |
+| `CUST-PRI-CARD-HOLDER-IND` semantics | **Treat as `PIC X(01)`** | Matches the copybook; do not coerce to `boolean` (some records may carry non-`Y`/`N` values from imports) |
+
+### 3.3 Why a sequential-file GnuCOBOL port
+
+Same pattern as `CBACT02C` / `CBACT03C`: `INDEXED SEQUENTIAL` → `LINE SEQUENTIAL INPUT` in the portable oracle (`CBCUS01P.cbl`). All other paragraphs verbatim.
+
+---
+
+## 4. Step-by-step migration steps
+
+| # | Step | Acceptance |
+| - | ---- | ---------- |
+| 1 | Define `CustomerRecord` (500-byte wrapper; ~16 typed accessors + `rawBytes()`). | Round-trip test parses `custdata.txt`, re-emits, byte-identical |
+| 2 | Implement `CustomerFileReader` (sequential 500-byte reader; pads short input lines). | Reads fixture; record count matches `wc -c / 500` |
+| 3 | Implement `CustomerFileProcessor.main()` — banners + dual-write loop + close + final banner. | Runs end-to-end |
+| 4 | Write `cobol-reference/CBCUS01P.cbl` (one-line `SELECT` change vs `CBCUS01C.cbl`). | Compiles; runs |
+| 5 | Extend `cobol-reference/tools/regen-golden.sh` to capture `CBCUS01P` SYSOUT. | Output captured |
+| 6 | Write `CustomerRecordRoundTripTest`, smoke test, and `CustomerFileGoldenFileEquivalenceIT`. | All pass |
+| 7 | Update `docs/cobol/batch-programs.md` `CBCUS01C` section pointer. | Pointer added |
+
+**Estimated effort:** ~5–7 hours. Slightly more than `CBACT02C` / `CBACT03C` because of the larger record (16 accessors vs 6) and the `CVCUS01Y`-vs-`CUSTREC` ambiguity that needs to be flagged in the domain class doc-comment.
+
+---
+
+## 5. Logic equivalency safeguards
+
+### 5.1 Duplicate-display
+
+Same as `CBACT03C` — both the inner `DISPLAY` (status `'00'` branch) and the outer mainline `DISPLAY` fire. Java must emit each record twice.
+
+### 5.2 Trailing FILLER preservation
+
+184 bytes of FILLER at offset 316. Preserve raw bytes; the COBOL `DISPLAY` includes them.
+
+### 5.3 Renamed helper paragraphs
+
+`CBCUS01C` uses `Z-ABEND-PROGRAM` and `Z-DISPLAY-IO-STATUS` (instead of `9999-` / `9910-`). The Java port doesn't care — same `BatchAbendException` and same logging behaviour. The portable oracle keeps the COBOL `Z-` names verbatim.
+
+### 5.4 GnuCOBOL `LINE SEQUENTIAL` quirks
+
+`COB_LS_FIXED=Y` required at run time so that 500-byte records read fully padded.
+
+### 5.5 Numeric field display
+
+`CUST-FICO-CREDIT-SCORE PIC 9(03)`, `CUST-SSN PIC 9(09)`, `CUST-ID PIC 9(09)` are all unsigned zoned — they `DISPLAY` as plain ASCII digits. No sign overpunch involved. The simpler case relative to `interest/`.
+
+---
+
+## 6. Test strategy
+
+### 6.1 Unit tests
+
+| Test class | Concern |
+| ---------- | ------- |
+| `CustomerRecordRoundTripTest` | parse → `rawBytes()` byte-identical for every record in `custdata.txt`; spot-check accessor values |
+| `CustomerFileReaderTest` | Reads N records from a 2-record synthetic fixture |
+
+### 6.2 Smoke test
+
+`CustomerFileProcessorTest` against a 1-record synthetic fixture; asserts exactly 4 SYSOUT lines.
+
+### 6.3 Golden-file integration test
+
+```
+1. cd cobol-reference && bash tools/regen-golden.sh
+2. mvn verify
+   → CustomerFileGoldenFileEquivalenceIT:
+       • runs CustomerFileProcessor.main(...)
+       • Files.mismatch(expected/sysout.txt, temp/sysout.txt) == -1L
+```
+
+### 6.4 Synthetic edge-case fixtures
+
+| Fixture | Purpose |
+| ------- | ------- |
+| `single-customer/` | 1 record → 4 SYSOUT lines |
+| `empty/` | 0 records → 2 SYSOUT banners only |
+| `unicode-ascii-boundary/` | Customer name with high-bit ASCII bytes (e.g. `ñ`) → ISO-8859-1 round-trips them as single bytes |
+
+---
+
+## 7. Documents to be produced during implementation
+
+1. Append a "CBCUS01C — Customer File Processor" section to
+   `app/java/batch_processing_workflow/README.md`.
+2. Append a CBCUS01C section to `HOW-TO-TEST.md`.
+3. After implementation, add the architecture companion
+   `docs/migration/CBCUS01C-java-architecture.md`.
+4. Add a doc-comment on `CustomerRecord` flagging the
+   `CVCUS01Y` vs `CUSTREC` distinction so future maintainers don't
+   conflate them.
+
+---
+
+## 8. Risks and open decisions
+
+### 8.1 Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `CustomerRecord` is later mistakenly reused for `CBSTM03A` (which uses `CUSTREC`, not `CVCUS01Y`) | Doc-comment + a separate `Stm03CustomerRecord` class in the `CBSTM03A` plan |
+| Same duplicate-display oversight as in `CBACT03C` | Smoke test asserts line count; IT catches byte-level drift |
+| Trailing 184-byte FILLER stripped by JVM `String` operations | `CustomerRecord` works on `byte[]` only; `rawBytes()` returns the buffer; no `String` conversion at write time |
+| Unicode mishandling on customer names with non-ASCII bytes | ISO-8859-1 single-byte identity I/O (silent killer prevention) |
+
+### 8.2 Open decisions to confirm
+
+- **`CustomerRecord` vs. extending an `interest`-package class** —
+  defaulting to a new `customer.domain.CustomerRecord`. No existing
+  class wraps `CVCUS01Y`, so this is non-controversial.
+- **Promotion of shared codecs** — assumed already done by the time
+  `CBCUS01C` is migrated (per the README sequencing). If not, do it
+  here.
+
+---
+
+## 9. Out of scope for this migration
+
+Same as `CBACT02C`/`CBACT03C` — this plan is `CBCUS01C` only.
+
+---
+
+## 10. Approval gate
+
+Confirm before implementation:
+
+1. **Defaults in §3.2** — accept or override.
+2. **Duplicate-display fidelity** — yes/no.
+3. **Scope locked** to `CBCUS01C` only — yes/no.
+
+Once confirmed, work proceeds through steps 1–7 in §4.

--- a/docs/migration/CBEXPORT-CBIMPORT-to-java-plan.md
+++ b/docs/migration/CBEXPORT-CBIMPORT-to-java-plan.md
@@ -1,0 +1,515 @@
+# Migration Plan: `CBEXPORT.cbl` + `CBIMPORT.cbl` → Java
+
+**Source programs:**
+- `app/cbl/CBEXPORT.cbl` — the **branch-migration export**: reads every record from each of the five master VSAM files and emits a single multi-record export VSAM file (KSDS keyed on a sequence counter). One COBOL record type per source file, distinguished by a single-byte `EXPORT-REC-TYPE` discriminator: `'C'`ustomer, `'A'`ccount, `'X'`ref, `'T'`ransaction, `'D'`-card.
+- `app/cbl/CBIMPORT.cbl` — the **inverse**: reads the multi-record `EXPFILE` and fans it out to five normalized **sequential** output files (customer / account / xref / transaction / card), one record-type per file, with an additional error file for unknown record types.
+
+The pair shares the central `CVEXPORT` 500-byte record layout (a header + a 460-byte payload `REDEFINES`-ed into five alternative shapes). They are migrated together to share the layout class and binary-numeric codecs.
+
+**Driving JCL:** `app/jcl/CBEXPORT.jcl`, `app/jcl/CBIMPORT.jcl` (separate jobs).
+
+**Target location (mandatory):** `app/java/batch_processing_workflow/`
+
+**Goal:** A Java port that produces, for both directions:
+
+- `CBEXPORT` Java run → `EXPFILE` byte-for-byte identical to the GnuCOBOL oracle's `EXPFILE`.
+- `CBIMPORT` Java run on the same `EXPFILE` → five output files plus the optional error file, each byte-for-byte identical to the GnuCOBOL oracle's outputs.
+
+This plan is purely a plan. **No code is written until approved.**
+
+---
+
+## 1. Source contract — what `CBEXPORT` and `CBIMPORT` do
+
+### 1.1 `CBEXPORT` inputs
+
+| DD name | Org / Access | Record (copybook) |
+| ------- | ------------ | ----------------- |
+| `CUSTFILE` | INDEXED / SEQUENTIAL | 500 bytes (`CVCUS01Y`) |
+| `ACCTFILE` | INDEXED / SEQUENTIAL | 300 bytes (`CVACT01Y`) |
+| `XREFFILE` | INDEXED / SEQUENTIAL | 50 bytes (`CVACT03Y`) |
+| `TRANSACT` | INDEXED / SEQUENTIAL | 350 bytes (`CVTRA05Y`) |
+| `CARDFILE` | INDEXED / SEQUENTIAL | 150 bytes (`CVACT02Y`) |
+
+### 1.2 `CBEXPORT` output
+
+| DD name | Org / Access | Record |
+| ------- | ------------ | ------ |
+| `EXPFILE` | INDEXED, OPENED `OUTPUT`, `RECORDING MODE F`, `RECORD CONTAINS 500` | 500 bytes (`CVEXPORT` — `EXPORT-RECORD`); KSDS keyed on `EXPORT-SEQUENCE-NUM PIC 9(9) COMP` (synthetic 4-byte big-endian) |
+
+### 1.3 `CBIMPORT` inputs
+
+| DD name | Org / Access | Record |
+| ------- | ------------ | ------ |
+| `EXPFILE` | KSDS or PS input; FD declares `RECORDING MODE F`, `RECORD CONTAINS 500` | 500 bytes (`CVEXPORT`) |
+
+### 1.4 `CBIMPORT` outputs
+
+| DD name | LRECL / RECFM | Source record |
+| ------- | ------------- | ------------- |
+| `CUSTOUT` | 500 / FB | `CVCUS01Y` shape (mapped from `EXP-CUSTOMER`) |
+| `ACCTOUT` | 300 / FB | `CVACT01Y` shape (from `EXP-ACCOUNT`) |
+| `XREFOUT` | 50 / FB | `CVACT03Y` shape (from `EXP-XREF`) |
+| `TRNXOUT` | 350 / FB | `CVTRA05Y` shape (from `EXP-TRANSACTION`) |
+| `CARDOUT` | 150 / FB | `CVACT02Y` shape (from `EXP-CARD`) |
+| `ERROUT` | 132 / FB | Pipe-delimited error log line |
+
+### 1.5 `CVEXPORT` layout — the central artefact (500 bytes)
+
+```
+01  EXPORT-RECORD.
+    05  EXPORT-HEADER.
+        10 EXPORT-REC-TYPE        PIC X(01).
+        10 EXPORT-TIMESTAMP       PIC X(26).
+        10 EXPORT-SEQUENCE-NUM    PIC 9(09) COMP.       (4-byte big-endian)
+        10 EXPORT-BRANCH          PIC X(04).
+        10 EXPORT-REGION          PIC X(05).
+    05  EXPORT-PAYLOAD            PIC X(455).
+        OR
+        EXP-CUSTOMER       — REDEFINES EXPORT-PAYLOAD with CUSTOMER fields
+        EXP-ACCOUNT        — REDEFINES with ACCOUNT fields (mixed COMP / COMP-3)
+        EXP-XREF           — REDEFINES with XREF fields
+        EXP-TRANSACTION    — REDEFINES with TRANSACTION fields (COMP-3 amounts)
+        EXP-CARD           — REDEFINES with CARD fields
+```
+
+Header is 1 + 26 + 4 + 4 + 5 = **40 bytes**. Payload is **460 bytes**. Total **500 bytes**. The exact field layout of each `EXP-...` redefinition needs to be tabulated from `app/cpy/CVEXPORT.cpy` — step 1 of §4.
+
+**Storage variants used in the payload:**
+
+- `PIC 9(n) COMP` — binary integer, `n ≤ 4` → 2 bytes; `5 ≤ n ≤ 9` → 4 bytes; `n ≥ 10` → 8 bytes (see IBM RM).
+- `PIC S9(p)V(s) COMP-3` — packed decimal, `ceil((p+s+1)/2)` bytes.
+- `PIC X(n)` — fixed-width text.
+
+**This is the only batch program in the catalog that uses `COMP` integers.** A new `BinaryIntegerCodec` is required.
+
+### 1.6 `CBEXPORT` algorithm
+
+```
+0000-MAIN-PROCESSING:
+    1000-INITIALIZE
+        1050-GENERATE-TIMESTAMP   build EXPORT-TIMESTAMP
+        OPEN INPUT  CUSTFILE, ACCTFILE, XREFFILE, TRANSACT, CARDFILE
+        OPEN OUTPUT EXPFILE
+        WS-SEQUENCE-COUNTER = 0
+    2000-EXPORT-CUSTOMERS
+        prime-read CUSTFILE; loop until EOF (status '10'):
+            2200-CREATE-CUST-EXP-REC:  populate header + EXP-CUSTOMER
+            ADD 1 TO WS-SEQUENCE-COUNTER
+            MOVE WS-SEQUENCE-COUNTER TO EXPORT-SEQUENCE-NUM
+            WRITE EXPORT-OUTPUT-RECORD FROM EXPORT-RECORD
+            ADD 1 TO WS-CUSTOMER-COUNT
+    3000-EXPORT-ACCOUNTS         (same pattern, EXP-ACCOUNT)
+    4000-EXPORT-XREFS            (same pattern, EXP-XREF)
+    5000-EXPORT-TRANSACTIONS     (same pattern, EXP-TRANSACTION)
+    5500-EXPORT-CARDS            (same pattern, EXP-CARD)
+    6000-FINALIZE
+        CLOSE all 6 files
+        DISPLAY total counts (one DISPLAY per record type)
+GOBACK
+```
+
+Output records are written in the order:
+**all customers → all accounts → all xrefs → all transactions → all cards**
+
+Each gets a monotonically increasing `EXPORT-SEQUENCE-NUM` starting from 1.
+
+### 1.7 `CBIMPORT` algorithm
+
+```
+0000-MAIN-PROCESSING:
+    1000-INITIALIZE
+        Build current date/time strings via FUNCTION CURRENT-DATE(1:4) etc.
+        OPEN all 6 input/output files
+    2000-PROCESS-EXPORT-FILE
+        prime-read EXPFILE; loop until EOF:
+            2200-PROCESS-RECORD-BY-TYPE:
+                EVALUATE EXPORT-REC-TYPE
+                    WHEN 'C': 2300-PROCESS-CUSTOMER-RECORD  (INITIALIZE; map fields; WRITE CUSTOUT)
+                    WHEN 'A': 2400-PROCESS-ACCOUNT-RECORD
+                    WHEN 'X': 2500-PROCESS-XREF-RECORD
+                    WHEN 'T': 2600-PROCESS-TRANSACTION-RECORD
+                    WHEN 'D': 2650-PROCESS-CARD-RECORD
+                    WHEN OTHER: 2700-PROCESS-UNKNOWN-RECORD → 2750-WRITE-ERROR (132-byte pipe-delimited)
+                ADD 1 TO appropriate counter
+    3000-VALIDATE-IMPORT (placeholder; always reports success)
+    4000-FINALIZE
+        CLOSE all files
+        DISPLAY counts per record type
+GOBACK
+```
+
+### 1.8 Numeric formats
+
+| Storage | Where it appears | Java codec |
+| ------- | ---------------- | ---------- |
+| Zoned decimal `S9(n)V(s)` | All source files; output PS files | `ZonedDecimalCodec` (existing) |
+| Packed decimal `S9(n)V(s) COMP-3` | `EXP-ACCOUNT`, `EXP-TRANSACTION` payloads | `PackedDecimalCodec` (from `CBACT01C` plan) |
+| Binary integer `9(n) COMP` | `EXP-CUST-ID PIC 9(09) COMP`, `EXPORT-SEQUENCE-NUM`, etc. | NEW `BinaryIntegerCodec` |
+
+### 1.9 Timestamps
+
+`1050-GENERATE-TIMESTAMP` in `CBEXPORT` builds a 26-byte timestamp via `ACCEPT FROM DATE YYYYMMDD` and `ACCEPT FROM TIME` plus `STRING`-based formatting. **This is** non-deterministic — must be injected.
+
+`CBIMPORT`'s `1000-INITIALIZE` similarly does `MOVE FUNCTION CURRENT-DATE(1:4) TO …` — non-deterministic. Must be injected.
+
+Both tap into a shared `Db2Timestamp.useFixedClock(...)` for tests.
+
+---
+
+## 2. Equivalence requirements (acceptance criteria)
+
+### 2.1 `CBEXPORT` direction
+
+1. **`EXPFILE`** matches byte-for-byte (500-byte records).
+
+`Files.mismatch(expected/expfile.dat, actual/expfile.dat) == -1L`
+
+### 2.2 `CBIMPORT` direction
+
+1. **`CUSTOUT`** (500-byte records) byte-for-byte.
+2. **`ACCTOUT`** (300-byte records) byte-for-byte.
+3. **`XREFOUT`** (50-byte records) byte-for-byte.
+4. **`TRNXOUT`** (350-byte records) byte-for-byte.
+5. **`CARDOUT`** (150-byte records) byte-for-byte.
+6. **`ERROUT`** (132-byte pipe-delimited records) byte-for-byte. Empty file if no unknown records.
+
+### 2.3 Round-trip property
+
+Beyond Java≡COBOL byte-equivalence, the pair has a useful round-trip property:
+
+- `original master files → CBEXPORT (Java) → CBIMPORT (Java) → reconstructed master files`
+
+The reconstructed files should equal the originals **for the fields the export carries**. (Some shape-dependent fields like FILLER may differ, since `CBIMPORT` `INITIALIZE`s the destination record before the field-by-field copy.) This is captured as a non-blocking `RoundTripPropertyTest` for confidence; the hard acceptance is the GnuCOBOL byte-equivalence.
+
+### 2.4 Sources of divergence to neutralize
+
+- **`EXPORT-TIMESTAMP`** in every record. Inject via
+  `Db2Timestamp.useFixedClock(...)` and a COBOL compile-time switch.
+- **`CBIMPORT`'s current-date string** (used in `ERROUT` lines). Same
+  treatment.
+
+---
+
+## 3. Target architecture
+
+### 3.1 Layout
+
+```
+app/java/batch_processing_workflow/
+└── src/
+    ├── main/java/com/carddemo/batch/
+    │   ├── exportimport/                              ← new subpackage for the pair
+    │   │   ├── DataExporter.java                      main(); mirrors CBEXPORT
+    │   │   ├── DataImporter.java                      main(); mirrors CBIMPORT
+    │   │   ├── domain/
+    │   │   │   ├── ExportRecord.java                  500-byte multi-shape record
+    │   │   │   ├── ExportHeader.java                  40-byte header
+    │   │   │   ├── CustomerPayload.java               460-byte EXP-CUSTOMER shape
+    │   │   │   ├── AccountPayload.java                460-byte EXP-ACCOUNT shape (mixed COMP/COMP-3)
+    │   │   │   ├── XrefPayload.java                   460-byte EXP-XREF shape
+    │   │   │   ├── TransactionPayload.java            460-byte EXP-TRANSACTION shape (COMP-3)
+    │   │   │   └── CardPayload.java                   460-byte EXP-CARD shape
+    │   │   ├── io/
+    │   │   │   ├── BinaryIntegerCodec.java            NEW — emulates COMP big-endian integers
+    │   │   │   ├── ExportFileWriter.java              500-byte append; preserves source-file order
+    │   │   │   ├── ExportFileReader.java              prime-read + sequential next
+    │   │   │   ├── (per-output) CustomerOutputWriter, AccountOutputWriter, … (5 writers, 1 per type)
+    │   │   │   └── ErrorOutputWriter.java             132-byte pipe-delimited
+    │   │   └── format/
+    │   │       └── ErrorLineBuilder.java              builds 132-byte pipe-delimited ERROUT line
+    │   ├── account/                                   ← UNCHANGED (provides PackedDecimalCodec)
+    │   ├── interest/                                  ← UNCHANGED (provides ZonedDecimalCodec, Db2Timestamp)
+    │   └── …
+    └── test/java/com/carddemo/batch/exportimport/
+        ├── BinaryIntegerCodecTest.java
+        ├── ExportRecordRoundTripTest.java             encode → decode for all 5 shapes
+        ├── DataExporterTest.java
+        ├── DataImporterTest.java
+        ├── DataExportImportRoundTripTest.java         CBEXPORT→CBIMPORT pipeline; reconstructs originals
+        ├── ExportGoldenFileEquivalenceIT.java
+        └── ImportGoldenFileEquivalenceIT.java
+```
+
+### 3.2 Decisions
+
+| Decision | Default | Why |
+| -------- | ------- | --- |
+| Java version | **Java 17** | Same module |
+| Codecs | **Reuse `ZonedDecimalCodec` + `PackedDecimalCodec`; add new `BinaryIntegerCodec`** | The pair is the only catalog entry using all three at once |
+| Multi-shape `ExportRecord` | **One Java class with five typed views** (`asCustomer()`, `asAccount()`, …) backed by a 500-byte buffer | Mirrors the `REDEFINES` semantics; preserves byte-equivalence on round-trip |
+| `EXPORT-SEQUENCE-NUM` storage | **`BinaryIntegerCodec.writeInt32BE(buf, 31, value)`** | 4-byte big-endian; matches z/OS `COMP` |
+| `EXPFILE` ordering | **Strict source-order: customers (by KSDS key), accounts, xrefs, transactions, cards** | Matches the `EXPORT-CUSTOMERS` → `EXPORT-CARDS` paragraph chain in `CBEXPORT` |
+| Sequence counter init | **1, monotonic** | First customer record has sequence 1 |
+| `CBIMPORT` `INITIALIZE` semantics | **Java equivalent: zero/space-fill the destination record before field-by-field copy** | Matches COBOL `INITIALIZE` behaviour; FILLER bytes become spaces, numerics become zeros |
+| Unknown record handler | **Pipe-delimited 132-byte error line** | Matches `2700-PROCESS-UNKNOWN-RECORD` |
+| `3000-VALIDATE-IMPORT` | **Empty stub with a `// TODO: validation per CBIMPORT.cbl`** | Faithful to the source's placeholder |
+| Timestamp injection | **`Db2Timestamp.useFixedClock(...)`** | Reuse |
+
+### 3.3 New shared utility — `BinaryIntegerCodec`
+
+```java
+public final class BinaryIntegerCodec {
+    public static int  readUnsignedInt16BE(byte[] buf, int offset);
+    public static int  readUnsignedInt32BE(byte[] buf, int offset);
+    public static long readUnsignedInt64BE(byte[] buf, int offset);
+
+    public static void writeUnsignedInt16BE(byte[] buf, int offset, int value);
+    public static void writeUnsignedInt32BE(byte[] buf, int offset, int value);
+    public static void writeUnsignedInt64BE(byte[] buf, int offset, long value);
+
+    public static int byteWidthForDigits(int digits);
+    // 1–4 digits → 2 bytes; 5–9 → 4 bytes; 10–18 → 8 bytes
+}
+```
+
+Promoted to shared `com.carddemo.batch.io` package as part of this plan (no other batch programs use COMP integers — the pair is the first and only consumer right now, but a future `EXEC SQL` host-variable port would reuse).
+
+### 3.4 Why a sequential-file GnuCOBOL port
+
+`CBEXPORT-P.cbl`:
+- All five INDEXED inputs change from `INDEXED SEQUENTIAL` to `LINE
+  SEQUENTIAL INPUT` (already sequential access; `INDEXED` is a no-op
+  for the read path).
+- `EXPFILE` (output, INDEXED) → `RECORD SEQUENTIAL` with explicit
+  fixed `RECORD CONTAINS 500 CHARACTERS` clause. **Cannot use `LINE
+  SEQUENTIAL`** because the binary `COMP` and `COMP-3` bytes contain
+  newline-equivalent values (`0x0A`, `0x0D`) that `LINE SEQUENTIAL`
+  would interpret as record terminators.
+- All business-logic paragraphs verbatim.
+- `1050-GENERATE-TIMESTAMP` replaced with a `MOVE 'fixed-string'`
+  under a `-DTEST_FIXED_TS` switch.
+
+`CBIMPORT-P.cbl`:
+- `EXPFILE` (input, INDEXED) → `RECORD SEQUENTIAL` with `RECORD
+  CONTAINS 500 CHARACTERS`.
+- All five outputs were already PS — `LINE SEQUENTIAL OUTPUT`. **But**
+  the source records contain no embedded binary, so `LINE SEQUENTIAL`
+  is safe for the outputs.
+- `ERROUT` was already PS — `LINE SEQUENTIAL OUTPUT`.
+- Current-date construction in `1000-INITIALIZE` replaced with the
+  same `-DTEST_FIXED_TS` switch.
+
+---
+
+## 4. Step-by-step migration steps
+
+| # | Step | Acceptance |
+| - | ---- | ---------- |
+| 1 | Tabulate `CVEXPORT.cpy` from `app/cpy/`. List every field in `EXP-CUSTOMER`, `EXP-ACCOUNT`, `EXP-XREF`, `EXP-TRANSACTION`, `EXP-CARD` with: offset, length, PIC, storage (DISPLAY/COMP/COMP-3), source-file field. Verify each shape is exactly 460 bytes. | Tables added as appendix to this plan |
+| 2 | Implement `BinaryIntegerCodec` (read+write for 16, 32, 64-bit big-endian unsigned). | Unit test covers boundary values, max ranges |
+| 3 | Define `ExportHeader` (40 bytes: 1 type + 26 ts + 4 seq + 4 branch + 5 region). | Round-trip test |
+| 4 | Define `CustomerPayload` (460 bytes from `CVCUS01Y` mapping). | Round-trip with synthetic record |
+| 5 | Define `AccountPayload` (460 bytes; mixed zoned + COMP-3 from `CVACT01Y`). | Round-trip; specifically verify COMP-3 amounts encode correctly |
+| 6 | Define `XrefPayload`, `TransactionPayload`, `CardPayload` (similar). | Round-trips |
+| 7 | Define `ExportRecord` — 500-byte container with `getHeader()`, `asCustomer()`, `asAccount()`, …, `asCard()` and a `recordType()` getter. | Test that `record.asCustomer().toBytes()` round-trips through `ExportRecord.fromBytes(bytes)` byte-identically |
+| 8 | Implement `ExportFileWriter` (500-byte append) and `ExportFileReader` (prime-read + sequential next). | Smoke tests |
+| 9 | Implement `DataExporter.main()` — opens 5 inputs, walks each in source order, builds payloads, increments sequence, writes to `EXPFILE`. | Runs end-to-end on fixtures |
+| 10 | Implement the 5 output writers + `ErrorOutputWriter`. | Smoke tests |
+| 11 | Implement `DataImporter.main()` — opens `EXPFILE`, dispatches per record type, INITIALIZEs+maps+writes destination, increments counters. Unknown type → error line. | Runs end-to-end |
+| 12 | Write `cobol-reference/CBEXPORT-P.cbl` and `CBIMPORT-P.cbl` (sequential ports as in §3.4) plus build/run/regen scripts (`-fsign=EBCDIC`, `COB_LS_FIXED=Y`, `-DTEST_FIXED_TS`). | `bash regen-golden.sh` produces `fixtures/expected/{expfile.dat, custout.dat, acctout.dat, xrefout.dat, trnxout.dat, cardout.dat, errout.dat}` |
+| 13 | Write the unit tests in §6. | All pass |
+| 14 | Write `ExportGoldenFileEquivalenceIT` and `ImportGoldenFileEquivalenceIT`. | Both pass |
+| 15 | Write `DataExportImportRoundTripTest` (Java→Java pipeline; reconstructs originals modulo INITIALIZE artifacts). | Passes |
+| 16 | Update `docs/cobol/batch-programs.md` `CBEXPORT` and `CBIMPORT` section pointers. | Pointers added |
+
+**Estimated effort:** ~3–4 engineering days. The bulk is in step 1 (tabulation; ~150 fields across 5 payload shapes) and steps 4–7 (codec mapping). Step 2 is small (~50 lines plus tests).
+
+---
+
+## 5. Logic equivalency safeguards
+
+### 5.1 `EXPORT-SEQUENCE-NUM` byte order
+
+`PIC 9(09) COMP` is a 4-byte signed big-endian integer on z/OS. **Big-endian, not little-endian.** `BinaryIntegerCodec.writeUnsignedInt32BE(buf, 31, value)` writes the high byte first. A test must assert `seq=1 → bytes [0x00, 0x00, 0x00, 0x01]`, not `[0x01, 0x00, 0x00, 0x00]`.
+
+### 5.2 Sequence counter spans all five record types
+
+The counter increments once per output record, not once per source file. Customer 1 → seq 1; customer 2 → seq 2; …; first account → seq (custCount + 1); etc. After all 5 source files, the maximum seq equals the total record count.
+
+### 5.3 COMP-3 storage in the export
+
+`EXP-ACCT-CURR-BAL PIC S9(10)V99 COMP-3` → 7 bytes packed decimal. Reuse `PackedDecimalCodec` from the `CBACT01C` plan. A round-trip test on a known account record must produce identical bytes through the export pipeline.
+
+### 5.4 `INITIALIZE` semantics on output records in `CBIMPORT`
+
+Each handler does `INITIALIZE CUSTOMER-RECORD` before mapping fields. COBOL `INITIALIZE` zeros all numeric fields (zoned and packed) and spaces all alphanumeric fields. **Then** the field-by-field MOVE overwrites only the fields carried by the export.
+
+Java equivalent for the customer write:
+
+```java
+byte[] custBuf = new byte[500];
+Arrays.fill(custBuf, (byte) ' ');                              // alphanumeric initialize
+// (numeric INITIALIZE: zeros at known offsets — handled by MOVE below)
+// Field-by-field map from EXP-CUSTOMER to CVCUS01Y:
+FixedWidthFormat.writeUnsignedNumeric(custBuf, 0, 9, exp.getCustId());
+FixedWidthFormat.writeText(custBuf, 9, 25, exp.getFirstName());
+// ... etc
+out.write(custBuf);
+```
+
+Bytes that aren't in the EXP shape (e.g. fields the export elected not to carry) keep their `INITIALIZE` defaults — typically zeros and spaces. **The Java port must zero numerics that aren't overwritten**, since `Arrays.fill(buf, (byte) ' ')` doesn't zero them.
+
+### 5.5 Multi-record `REDEFINES` byte-fidelity
+
+When `ExportRecord.fromBytes(bytes)` is called, the 460-byte payload is preserved as-is regardless of the record type. `asCustomer()` etc. return typed views over the same bytes. **The container does not interpret the payload during reads — only the destination view does.** This means a malformed record (e.g. `EXPORT-REC-TYPE='C'` but the payload bytes are an account shape) round-trips without rejection on read. The error path is in `CBIMPORT.2200-PROCESS-RECORD-BY-TYPE` `WHEN OTHER`.
+
+### 5.6 Unknown record-type pipe-delimited error line
+
+```
+seq=NNN | type='?' | timestamp=YYYY-MM-DD-HH.MI.SS.MIL0000 | (raw payload, ASCII-printable subset, truncated to 132 bytes)
+```
+
+Exact format must be lifted from `2700-PROCESS-UNKNOWN-RECORD` in source. The 132-byte hard length includes all delimiters and any truncation marker.
+
+### 5.7 Five output FB record-length enforcement
+
+After each handler, the byte count written to the destination must equal that file's LRECL exactly:
+- 500 bytes per CUSTOUT record
+- 300 per ACCTOUT
+- 50 per XREFOUT
+- 350 per TRNXOUT
+- 150 per CARDOUT
+
+A unit test per handler asserts the exact length. The IT then catches any drift.
+
+### 5.8 `RECORD SEQUENTIAL` vs `LINE SEQUENTIAL` — binary content
+
+The `EXPFILE` contains binary `COMP` + `COMP-3` bytes that may include `0x0A` or `0x0D`. `LINE SEQUENTIAL` would interpret these as record terminators and corrupt the file. The portable oracle uses `RECORD SEQUENTIAL` with `RECORD CONTAINS 500 CHARACTERS`. Java's writer / reader work on raw bytes (no LF handling) — this is automatic.
+
+### 5.9 Round-trip property (non-blocking)
+
+`Java CBEXPORT → Java CBIMPORT → reconstructed master files`:
+
+- Fields *carried* by the export should round-trip byte-identically.
+- Fields *not carried* (FILLER, fields the export omits) end up as INITIALIZEd defaults in the reconstructed files — likely **different** from the originals.
+
+The `DataExportImportRoundTripTest` documents which fields drift and asserts the carried ones are stable. The hard acceptance criterion is the GnuCOBOL byte-equivalence (§2), not the round-trip.
+
+---
+
+## 6. Test strategy
+
+### 6.1 Unit tests
+
+| Test class | Concern |
+| ---------- | ------- |
+| `BinaryIntegerCodecTest` | 16/32/64-bit big-endian round-trips; max boundaries; zero |
+| `ExportRecordRoundTripTest` | All 5 record types; encode → decode → compare bytes |
+| `CustomerPayloadTest` | Field offsets and lengths match `CVEXPORT.cpy` |
+| `AccountPayloadTest` | Same; specifically COMP-3 amounts |
+| `XrefPayloadTest` | Same |
+| `TransactionPayloadTest` | Same; COMP-3 amounts |
+| `CardPayloadTest` | Same |
+| `ErrorLineBuilderTest` | Byte-exact 132-byte error line for known unknown-type input |
+
+### 6.2 Smoke tests
+
+| Test class | Concern |
+| ---------- | ------- |
+| `DataExporterTest` | 5-file synthetic input → 5-record `EXPFILE` (1 of each type) |
+| `DataImporterTest` | 5-record `EXPFILE` → 5 output files (1 record each), `ERROUT` empty |
+| `DataImporterUnknownTypeTest` | 1 record with `EXPORT-REC-TYPE='Z'` → 0 output records, 1 ERROUT line |
+
+### 6.3 Round-trip property test
+
+`DataExportImportRoundTripTest`: pipes Java `CBEXPORT` → Java `CBIMPORT`; asserts the carried fields equal the originals. Lists the drift fields explicitly so future maintainers don't think the test is broken.
+
+### 6.4 Golden-file integration tests
+
+```
+1. cd cobol-reference && bash tools/regen-export-golden.sh
+   → builds CBEXPORT-P
+   → runs against the same source fixtures used by CBACT0[1234]C oracles
+   → cp expfile.dat → fixtures/expected/
+
+2. mvn verify
+   → ExportGoldenFileEquivalenceIT
+       Files.mismatch(expected/expfile.dat, temp/expfile.dat) == -1L
+
+3. cd cobol-reference && bash tools/regen-import-golden.sh
+   → builds CBIMPORT-P
+   → runs against the COBOL-produced expfile.dat
+   → cp the 6 outputs → fixtures/expected/
+
+4. mvn verify
+   → ImportGoldenFileEquivalenceIT
+       Files.mismatch(expected, temp) == -1L for all 6 outputs
+```
+
+### 6.5 Synthetic edge-case fixtures
+
+| Fixture | Purpose |
+| ------- | ------- |
+| `single-of-each/` | 1 customer, 1 account, 1 xref, 1 transaction, 1 card → 5-record `EXPFILE` (sequence 1–5) |
+| `large-set/` | 100 customers → exercise sequence number 100 (`COMP` 4-byte big-endian `0x00 0x00 0x00 0x64`) |
+| `unknown-type/` | manually crafted `EXPFILE` with `EXPORT-REC-TYPE='Z'` → tests `WHEN OTHER` branch |
+| `comp3-boundary/` | Account with `ACCT-CURR-BAL = -9999999999.99` → exercises sign nibble + max-magnitude packed decimal |
+
+---
+
+## 7. Documents to be produced during implementation
+
+1. Append "CBEXPORT" and "CBIMPORT" sections to
+   `app/java/batch_processing_workflow/README.md`.
+2. Append a CBEXPORT/CBIMPORT section to `HOW-TO-TEST.md` covering the
+   two-stage golden flow (export then import).
+3. Add `docs/migration/CBEXPORT-CBIMPORT-java-architecture.md`.
+4. Update `docs/cobol/batch-programs.md` `CBEXPORT` and `CBIMPORT`
+   sections with pointers.
+5. Document the new `BinaryIntegerCodec` API in shared `io` javadoc.
+6. The full `CVEXPORT` field-by-field tabulation (from step 1 of §4)
+   lands as an appendix to this plan.
+
+---
+
+## 8. Risks and open decisions
+
+### 8.1 Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `BinaryIntegerCodec` byte order wrong (little- vs big-endian) → silent diff | Unit test asserts `seq=1 → [0x00, 0x00, 0x00, 0x01]` |
+| `LINE SEQUENTIAL OUTPUT` mishandling binary content in `EXPFILE` | `RECORD SEQUENTIAL` + explicit `RECORD CONTAINS 500` in oracle |
+| `INITIALIZE` semantics partially replicated in Java (alphanumerics OK, numerics missed) | `DataImporterTest` round-trip plus a unit test that asserts byte 0 of every numeric field is `0x00` (or `0x30` for zoned) before the field-by-field copy |
+| 460-byte payload allocation drift between record types (a `REDEFINES` shape that's only 459 bytes) | Step 1 tabulation enforces 460-byte invariant; per-payload tests catch a 1-byte miscount |
+| Round-trip property fails because export drops a field; user reads it as a regression | `DataExportImportRoundTripTest` documents drift fields explicitly; assertion only on carried fields |
+| `EXPORT-TIMESTAMP` injection forgotten → IT shows random 26-byte drift in every record | `Db2Timestamp.useFixedClock` in `@BeforeAll`; CLI exposes `--ts=` flag |
+
+### 8.2 Open decisions to confirm
+
+1. **Pair migrated together** — yes (recommended) or split.
+2. **`EXPFILE` write order strict** (customers → accounts → xrefs → transactions → cards) — accept (matches source).
+3. **`INITIALIZE` numerics zeroing** — accept the explicit zero-fill before field-by-field copy.
+4. **`3000-VALIDATE-IMPORT` stub** — leave as no-op (faithful) or implement post-port. Recommend leave as no-op with `// TODO`.
+5. **Defaults in §3.2** — accept or override.
+6. **Scope locked** to the pair only — yes/no.
+
+---
+
+## 9. Out of scope for this migration
+
+- `CBEXPORT`'s `OPEN OUTPUT INDEXED` semantics for VSAM (real VSAM
+  ABENDs on out-of-order keys; the portable oracle and Java port use
+  sequential output).
+- Cross-version export-format compatibility. The export format is
+  treated as a snapshot; older versions of `CVEXPORT` aren't
+  supported.
+- `3000-VALIDATE-IMPORT` — the source treats this as a placeholder
+  that always succeeds; the Java port matches.
+
+---
+
+## 10. Approval gate
+
+Confirm before implementation:
+
+1. **Pair migrated together** — yes/no.
+2. **`BinaryIntegerCodec` promoted** to shared `io` — yes (recommended).
+3. **`INITIALIZE` semantics** — explicit zero-fill numerics + space-fill
+   alphanumerics — yes/no.
+4. **`3000-VALIDATE-IMPORT`** — leave as stub or implement.
+5. **Defaults in §3.2** — accept or override.
+6. **Scope locked** to the pair only — yes/no.
+
+Once confirmed, work proceeds through steps 1–16 in §4.

--- a/docs/migration/CBSTM03A-CBSTM03B-to-java-plan.md
+++ b/docs/migration/CBSTM03A-CBSTM03B-to-java-plan.md
@@ -1,0 +1,489 @@
+# Migration Plan: `CBSTM03A.CBL` + `CBSTM03B.CBL` → Java
+
+**Source programs:**
+- `app/cbl/CBSTM03A.CBL` — the **statement creator**: business logic, formatting, two output streams (FB-80 plain text and FB-100 HTML).
+- `app/cbl/CBSTM03B.CBL` — the **file-handler subprogram**: a generic dispatcher that opens / reads (sequential or keyed) / closes one of four KSDS files behind a single `CALL` interface.
+
+The two programs are migrated as a pair because they are operationally inseparable: `CBSTM03A` performs no file I/O directly — every file operation goes through `CALL 'CBSTM03B' USING WS-M03B-AREA`.
+
+**Driving JCL:** `app/jcl/CREASTMT.JCL` step `STEP040`. Earlier steps build a `(card-num, tran-id)`-keyed copy of the transaction master so this program can read it sequentially.
+
+**Target location (mandatory):** `app/java/batch_processing_workflow/`
+
+**Goal:** A Java port that produces **byte-for-byte identical output** to the COBOL run on both the FB-80 plain text statement file (`STMTFILE`) and the FB-100 HTML statement file (`HTMLFILE`), verified by an automated test that diffs against a GnuCOBOL-runnable reference build.
+
+This plan is purely a plan. **No code is written until approved.**
+
+---
+
+## 1. Source contract — what the pair does
+
+### 1.1 Inputs (all accessed via `CBSTM03B`)
+
+| DD name | Org / Access | Record | Notes |
+| ------- | ------------ | ------ | ----- |
+| `TRNXFILE` | INDEXED / SEQUENTIAL | 350 bytes (`COSTM01` — `TRNX-RECORD`) | Composite key `TRNX-CARD-NUM + TRNX-ID` (32 bytes). Walked sequentially at start to load the in-memory transaction table. |
+| `XREFFILE` | INDEXED / SEQUENTIAL | 50 bytes (`CVACT03Y`) | Walked sequentially in the main loop to drive statement generation. |
+| `CUSTFILE` | INDEXED / RANDOM | 500 bytes — note: `CUSTREC` variant of `CVCUS01Y` (different field names) | Random read by `XREF-CUST-ID`. |
+| `ACCTFILE` | INDEXED / RANDOM | 300 bytes (`CVACT01Y`) | Random read by `XREF-ACCT-ID`. |
+
+### 1.2 Outputs (written directly by `CBSTM03A`)
+
+| DD name | LRECL / RECFM | Notes |
+| ------- | ------------- | ----- |
+| `STMTFILE` | 80 / FB | Plain-text statement; one statement per account spans many lines |
+| `HTMLFILE` | 100 / FB | HTML statement; same content as `STMTFILE` but wrapped in HTML tags |
+
+### 1.3 Algorithm (paragraph map for `CBSTM03A`)
+
+```
+PROCEDURE DIVISION:
+
+  Mainframe diagnostic prologue (skip in Java port):
+    SET ADDRESS OF PSA-BLOCK TO PSAPTR
+    Walk PSA → TCB → TIOT, DISPLAY each active DD name
+
+  OPEN STMTFILE / HTMLFILE directly:
+    OPEN OUTPUT STMTFILE
+    OPEN OUTPUT HTMLFILE
+
+  0000-START — uses ALTER + GO TO + EVALUATE WS-FL-DD to dispatch into
+                    one of:
+    8100-FILE-OPEN   (whose target is mutated by ALTER)
+    8200-XREFFILE-OPEN
+    8300-CUSTFILE-OPEN
+    8400-ACCTFILE-OPEN
+    8500-READTRNX-READ
+
+  Phase A: load TRNXFILE into memory
+    8100-TRNXFILE-OPEN (via CBSTM03B)
+    8500-READTRNX-READ loops until EOF, packing rows into
+        WS-CARD-TBL OCCURS 51 TIMES of (
+            WS-CARDNUM PIC X(16),
+            WS-TRAN-CNT PIC 9(02),
+            WS-TRAN-TBL OCCURS 10 TIMES of TRNX-ROW)
+        — i.e. up to 510 transactions across 51 cards
+
+  Phase B: open the lookup files
+    8200-XREFFILE-OPEN, 8300-CUSTFILE-OPEN, 8400-ACCTFILE-OPEN
+        (all via CBSTM03B with 'O' op-code)
+
+  Phase C: 1000-MAINLINE
+    PERFORM 1000-XREFFILE-GET-NEXT (sequential read via CBSTM03B 'R')
+    UNTIL EOF on XREFFILE:
+        2000-CUSTFILE-GET (CBSTM03B 'K' keyed read on XREF-CUST-ID)
+        3000-ACCTFILE-GET (CBSTM03B 'K' keyed read on XREF-ACCT-ID)
+        5000-CREATE-STATEMENT:
+            5100-WRITE-PLAINTEXT-HEADERS (multiple WRITE STMTFILE)
+            5200-WRITE-HTML-HEADERS      (multiple WRITE HTMLFILE)
+        4000-TRNXFILE-GET — walks WS-CARD-TBL for matching CARD-NUM,
+                           emits 6000-WRITE-TRANS for each transaction:
+            6000 writes one plaintext line + one HTML line per trans
+        Footer/totals (text + HTML)
+
+  CLOSE all 4 KSDS files via CBSTM03B 'C'
+  CLOSE STMTFILE / HTMLFILE directly
+  GOBACK
+```
+
+### 1.4 The `CBSTM03B` linkage interface — `WS-M03B-AREA`
+
+The single linkage record passed on every `CALL`:
+
+```
+05  WS-M03B-DD          PIC X(08).   * which DD name to dispatch on
+05  WS-M03B-OPER        PIC X(01).   * op code: O=open, C=close, R=read seq,
+                                                K=read keyed, W=write, Z=rewrite
+05  WS-M03B-RC          PIC X(02).   * file status returned
+05  WS-M03B-KEY         PIC X(25).   * key for keyed read
+05  WS-M03B-KEY-LN      PIC S9(4).   * key length
+05  WS-M03B-FLDT        PIC X(1000). * record buffer in/out
+```
+
+`WS-M03B-DD` values used by `CBSTM03A`:
+
+- `TRNXFILE` (8 chars exact)
+- `XREFFILE`
+- `CUSTFILE`
+- `ACCTFILE`
+
+`WS-M03B-OPER` values: `'O'`, `'C'`, `'R'`, `'K'`, `'W'`, `'Z'`.
+The `'W'` and `'Z'` paths are unused by `CBSTM03A` in this codebase.
+
+`CBSTM03B` dispatches on `LK-M03B-DD` (one paragraph per file) and on the `LK-M03B-OPER` 88-levels (`M03B-OPEN`, `M03B-CLOSE`, `M03B-READ`, `M03B-READ-K`, `M03B-WRITE`, `M03B-REWRITE`).
+
+### 1.5 The `ALTER` + `GO TO` jump table
+
+`CBSTM03A` contains the rare COBOL-74 pattern:
+
+```cobol
+0000-START.
+    EVALUATE WS-FL-DD
+        WHEN 'TRNXFILE' ALTER 8100-FILE-OPEN TO PROCEED TO 8100-TRNXFILE-OPEN
+        WHEN 'XREFFILE' ALTER 8100-FILE-OPEN TO PROCEED TO 8200-XREFFILE-OPEN
+        ... etc
+    END-EVALUATE
+    GO TO 8100-FILE-OPEN.
+
+8100-FILE-OPEN.
+    GO TO 8100-TRNXFILE-OPEN.    * default; mutated by the ALTER above
+```
+
+This is a self-modifying jump table — the `GO TO` target on line `8100-FILE-OPEN` is rewritten at run time. Java replaces it with a static `Map<String, Runnable>` dispatch:
+
+```java
+Map<String, Runnable> openByDd = Map.of(
+    "TRNXFILE", this::openTrnxFile,
+    "XREFFILE", this::openXrefFile,
+    "CUSTFILE", this::openCustFile,
+    "ACCTFILE", this::openAcctFile);
+openByDd.get(wsFlDd).run();
+```
+
+The pattern recurs for the other dispatch points. Each gets its own
+`Map<String, Runnable>`. **The rationale for keeping the dispatch
+explicit (instead of inlining everything) is byte-for-byte trace
+equivalence in any future SYSOUT-capture test.**
+
+### 1.6 The 2D OCCURS table — `WS-CARD-TBL`
+
+```
+01 WS-CARD-TBL.
+   05 WS-CARD-ROW OCCURS 51 TIMES.
+      10 WS-CARDNUM   PIC X(16).
+      10 WS-TRAN-CNT  PIC 9(02).
+      10 WS-TRAN-TBL  OCCURS 10 TIMES.
+         15 WS-TRAN-ROW. (typed copy of TRNX-RECORD fields)
+```
+
+Java equivalent: `Map<String, List<TrnxRow>>` where the key is
+`CARDNUM` (left-padded to 16 chars). The map handles up to 51
+distinct cards × 10 transactions each = 510 max transactions. Java
+can technically support more, but the COBOL hard limit must be
+mirrored: the Java port should `throw new BatchAbendException(999)`
+on overflow to match the VSAM-equivalent ABEND.
+
+### 1.7 Statement layouts — text and HTML
+
+Step 1 of §4 dumps every `STMTFILE` and `HTMLFILE` `WRITE` block from
+`CBSTM03A.CBL` and tabulates the byte-exact line composition. Both
+formats share identical underlying data; only the framing differs.
+
+The HTML output uses `STRING ... DELIMITED BY '*'` as a no-op
+delimiter to make `STRING` behave as concatenation, and uses an
+88-level "literal pool" pattern: each fixed HTML fragment is a `VALUE`
+of `HTML-FIXED-LN` and is "selected" via `SET HTML-Lxx TO TRUE`
+immediately before the `WRITE`. Java replaces this with a
+`Map<String, byte[]>` of HTML fragments and string concatenation.
+
+### 1.8 Customer record variant — `CUSTREC` vs `CVCUS01Y`
+
+`CBSTM03A` uses `COPY CUSTREC` whose `CUST-DOB` field is named
+`CUST-DOB-YYYYMMDD` (no dashes), with a different downstream slicing
+than `CVCUS01Y`'s `CUST-DOB-YYYY-MM-DD`. **Distinct from `CVCUS01Y`** —
+do not reuse `CustomerRecord` from the `CBCUS01C` plan.
+
+A separate domain class `Stm03CustomerRecord` is required.
+
+---
+
+## 2. Equivalence requirements (acceptance criteria)
+
+Two artifacts must match byte-for-byte:
+
+1. **`STMTFILE`** — every byte of every 80-byte record.
+2. **`HTMLFILE`** — every byte of every 100-byte record.
+
+**Acceptance test:** `Files.mismatch(expected, actual) == -1L` for both.
+
+**Sources of divergence to neutralize:**
+
+- **Statement-date / generation-time fields** — `CBSTM03A` may (verify
+  in step 1) call `FUNCTION CURRENT-DATE` for a "Statement generated:
+  YYYY-MM-DD HH:MM:SS" line. Inject via
+  `Db2Timestamp.useFixedClock(...)`. COBOL oracle gets a compile-time
+  switch.
+
+**Mainframe-only features that don't appear in the byte-for-byte test:**
+
+- The PSA → TCB → TIOT walk (`SET ADDRESS OF PSA-BLOCK TO PSAPTR`) —
+  this code emits diagnostics to `SYSOUT` but writes nothing to the
+  two output files. The Java port stubs it out (logs "DD walk: not
+  applicable on Linux") and the IT does not check SYSOUT.
+
+---
+
+## 3. Target architecture
+
+### 3.1 Layout
+
+```
+app/java/batch_processing_workflow/
+└── src/
+    ├── main/java/com/carddemo/batch/
+    │   ├── statement/                                  ← new subpackage for the pair
+    │   │   ├── StatementCreator.java                   main(); mirrors CBSTM03A PROCEDURE DIVISION
+    │   │   ├── domain/
+    │   │   │   ├── TrnxRecord.java                     wraps COSTM01 (350 bytes)
+    │   │   │   └── Stm03CustomerRecord.java            wraps CUSTREC variant (500 bytes)
+    │   │   ├── store/
+    │   │   │   ├── TransactionTable.java               2D OCCURS table → Map<String, List<TrnxRow>>
+    │   │   │   └── FileGateway.java                    replaces CBSTM03B linkage
+    │   │   ├── format/
+    │   │   │   ├── PlainTextStatementBuilder.java      80-byte FB writer
+    │   │   │   └── HtmlStatementBuilder.java           100-byte FB writer
+    │   │   └── dispatch/
+    │   │       └── DispatchTable.java                  Map<String, Runnable> replacement for ALTER+GO TO
+    │   ├── account/                                    ← UNCHANGED (provides ExtractAccountRecord)
+    │   ├── interest/                                   ← UNCHANGED (provides Db2Timestamp)
+    │   └── …
+    └── test/java/com/carddemo/batch/statement/
+        ├── TrnxRecordRoundTripTest.java
+        ├── Stm03CustomerRecordRoundTripTest.java
+        ├── TransactionTableTest.java                   51 × 10 capacity, ABEND on overflow
+        ├── FileGatewayTest.java                        every (DD, op) combination
+        ├── PlainTextStatementBuilderTest.java          byte-exact for known statement
+        ├── HtmlStatementBuilderTest.java               byte-exact for known statement
+        ├── DispatchTableTest.java                      open / read / close per DD
+        ├── StatementCreatorTest.java                   end-to-end smoke
+        └── StatementGoldenFileEquivalenceIT.java       diff vs. GnuCOBOL oracle for STMT and HTML
+```
+
+### 3.2 Decisions
+
+| Decision | Default | Why |
+| -------- | ------- | --- |
+| Java version | **Java 17** | Same module |
+| `CBSTM03B` translation | **`FileGateway` class** with `Map<String, FileChannel>` keyed on DD name + a switch on operation char | Replaces the linkage-area pattern with a clean façade. Not exposed publicly — internal to `statement/` |
+| `WS-M03B-AREA` translation | **`GatewayRequest` record** `{ String dd; char op; String key; int keyLen; byte[] buffer; }` | Structural mirror without exposing internals |
+| `WS-CARD-TBL` translation | **`Map<String, List<TrnxRow>>`** with insertion-order semantics | Matches the COBOL "first card seen → first row" ordering |
+| Capacity limit | **Hard 51 × 10 enforced** with `BatchAbendException(999)` on overflow | Faithful to COBOL OCCURS limits |
+| `ALTER` + `GO TO` translation | **`DispatchTable` (`Map<String, Runnable>`)** | Idiomatic Java; same observable behaviour |
+| Diagnostic PSA/TCB/TIOT walk | **Stubbed**, logs "DD walk skipped on Linux" | Mainframe-only; no portable analog |
+| HTML literal pool | **`Map<String, byte[]>` of HTML fragments**, indexed by the same identifiers `CBSTM03A` uses | Direct byte equivalence; no template engine |
+| Statement-date injection | **`Db2Timestamp.useFixedClock(...)`** in tests; `--ts=` CLI flag for manual runs | Reuse from `interest/util` |
+| Output writers | **Direct `Files.newOutputStream(...)`** with explicit byte writes | No buffered text I/O; ISO-8859-1 byte identity |
+
+### 3.3 Why a sequential-file GnuCOBOL port
+
+`CBSTM03P-A.cbl` and `CBSTM03P-B.cbl`:
+
+- All four KSDS files in `CBSTM03B` change from INDEXED to LINE
+  SEQUENTIAL with in-memory tables loaded at OPEN time. `READ` and
+  `READ … KEY IS` become `SEARCH ALL` over the table.
+- `STMTFILE` and `HTMLFILE` were already sequential — no change beyond
+  ensuring `COB_LS_FIXED=Y` is exported at run time.
+- `ALTER … GO TO` is preserved verbatim — GnuCOBOL accepts the syntax.
+- The PSA/TCB/TIOT walk is replaced by a `DISPLAY 'DD walk skipped'` so
+  SYSOUT doesn't ABEND; the IT doesn't check SYSOUT for this program.
+
+The `CBSTM03B` portable oracle keeps the linkage interface intact —
+the Java `FileGateway` mirrors the same DD names and op codes for
+trace-equivalence reasons (so a future SYSOUT-capture test can
+verify call sequencing).
+
+---
+
+## 4. Step-by-step migration steps
+
+| # | Step | Acceptance |
+| - | ---- | ---------- |
+| 1 | Tabulate every `WRITE STMTFILE FROM …` and `WRITE HTMLFILE FROM …` in `CBSTM03A.CBL`. Record byte offsets, fixed literals, dynamic fields. Append the table as an appendix to this plan. | Table complete; STMT lines = 80 bytes each; HTML lines = 100 bytes each |
+| 2 | Define `TrnxRecord` (350 bytes) and `Stm03CustomerRecord` (500 bytes, variant). | Round-trip tests |
+| 3 | Implement `TransactionTable` with 51 × 10 capacity and ABEND-on-overflow. | Capacity test passes |
+| 4 | Implement `FileGateway` mirroring `CBSTM03B`'s DD × op dispatch table. Loads each KSDS as `IndexedFileStore<K, V>` (read-only) on `'O'`; lookup on `'R'` (sequential next) or `'K'` (keyed). | `FileGatewayTest` covers the 4 × 4 combinations actually used |
+| 5 | Implement `DispatchTable` for `ALTER` + `GO TO` replacement. | Smoke test |
+| 6 | Implement `PlainTextStatementBuilder` — produces the FB-80 stream for one account given customer + account + transaction list. | Byte-exact test for one canonical statement |
+| 7 | Implement `HtmlStatementBuilder` — produces the FB-100 stream for one account. | Byte-exact test |
+| 8 | Implement `StatementCreator.main()` — wires phases A, B, C above; uses `FileGateway`, `TransactionTable`, `DispatchTable`, two builders. | End-to-end on fixtures |
+| 9 | Write `cobol-reference/CBSTM03P-A.cbl` and `CBSTM03P-B.cbl` (sequential-only oracles as in §3.3) plus build/run/regen scripts. | `bash regen-golden.sh` produces `fixtures/expected/{stmtfile.dat, htmlfile.dat}` |
+| 10 | Write `StatementGoldenFileEquivalenceIT`. | Passes |
+| 11 | Update `docs/cobol/batch-programs.md` `CBSTM03A` and `CBSTM03B` section pointers. | Pointers added |
+
+**Estimated effort:** ~3–4 engineering days. The hardest steps are 1 (tabulating every byte of the two output formats) and 9 (porting a 924-line + 230-line program pair). Steps 4 and 5 are mechanical.
+
+---
+
+## 5. Logic equivalency safeguards
+
+### 5.1 `ALTER`-pattern fidelity
+
+The Java `DispatchTable.run(ddName)` is observably equivalent to `ALTER 8100-FILE-OPEN TO PROCEED TO …; GO TO 8100-FILE-OPEN`. The order in which entries are added to the dispatch table doesn't matter — the dispatch is by-key, not by-insertion. The COBOL `ALTER` semantics are also by-key (the latest `ALTER` wins). Equivalence holds.
+
+### 5.2 51 × 10 capacity enforcement
+
+```java
+if (tranList.size() >= 10) throw new BatchAbendException(999);
+if (table.size() >= 51 && !table.containsKey(cardNum)) throw new BatchAbendException(999);
+```
+
+Without these checks, Java silently grows past the COBOL limit. A test fixture with 52 cards (or 11 transactions on one card) must trigger the ABEND.
+
+### 5.3 `STRING ... DELIMITED BY '*'` HTML concatenation
+
+```cobol
+STRING 'Hello' '*' WS-NAME '*' '<br>' DELIMITED BY '*' INTO HTML-LINE
+```
+
+`'*'` is treated as a delimiter — when the source field encounters it, the move stops. Since none of the literal HTML fragments contain `'*'`, the `STRING` verb effectively concatenates them all, then `'<br>'`. Java equivalent: plain string concatenation (or `StringBuilder.append`). **The `'*'` character must not appear in any source field** — verify by inspection.
+
+### 5.4 88-level HTML literal pool
+
+```cobol
+01  HTML-FIXED-LN PIC X(100).
+    88  HTML-L01 VALUE '<html><body>'.
+    88  HTML-L02 VALUE '<table>'.
+    ...
+SET HTML-L01 TO TRUE.        * loads HTML-FIXED-LN with the L01 value
+WRITE HTMLFILE FROM HTML-FIXED-LN.
+SET HTML-L02 TO TRUE.
+WRITE HTMLFILE FROM HTML-FIXED-LN.
+```
+
+Each `SET HTML-Lxx TO TRUE` rewrites `HTML-FIXED-LN` with the
+corresponding `VALUE`. Java equivalent: a `Map<String, byte[]>` of the
+fixed fragments; the writer writes the looked-up bytes directly.
+Important: the COBOL `VALUE` is right-padded with spaces to 100 bytes
+(the field's PIC width). Java must do the same: each fragment is
+exactly 100 bytes, padded.
+
+### 5.5 `SET ADDRESS OF PSA-BLOCK TO PSAPTR` skip
+
+The mainframe diagnostic prologue walks z/OS control blocks to print active DD names. On Linux this isn't possible. The Java port:
+
+```java
+log.info("DD walk skipped on Linux (z/OS control-block walk not portable)");
+```
+
+The portable COBOL oracle replaces the walk with the same `DISPLAY` line. Both sides produce no `STMTFILE`/`HTMLFILE` content from this step → invisible to the byte-equivalence check.
+
+### 5.6 First-card guard / final-flush semantics
+
+Walking `XREFFILE` in `1000-MAINLINE` → for each card, write a complete statement (header → details → footer). There's no "current card" carry-over between iterations like `CBACT04C`'s `1050-UPDATE-ACCOUNT`. Each iteration is self-contained.
+
+### 5.7 `TRNX-CARD-NUM` matching
+
+The `4000-TRNXFILE-GET` paragraph walks `WS-CARD-TBL` to find the row whose `WS-CARDNUM` matches the current `XREF-CARD-NUM`. Java: `Map<String, List<TrnxRow>>` lookup. **Exact-string match** — including any leading zeros and trailing spaces. Don't trim.
+
+### 5.8 LRECL=80 / LRECL=100 enforcement
+
+Every line in `STMTFILE` is exactly 80 bytes; every line in `HTMLFILE` is exactly 100 bytes. Each builder method asserts the output length before returning. Mismatches surface immediately, before any IT runs.
+
+### 5.9 Trailing-FILLER on output
+
+COBOL `WRITE` of a level-01 group writes the entire 80 (or 100) bytes including any trailing spaces from PIC-shorter-than-VALUE expansion. Java must preserve every byte; don't `trim()` lines.
+
+---
+
+## 6. Test strategy
+
+### 6.1 Unit tests
+
+| Test class | Concern |
+| ---------- | ------- |
+| `TrnxRecordRoundTripTest` | parse → `rawBytes()` byte-identical |
+| `Stm03CustomerRecordRoundTripTest` | parse → bytes |
+| `TransactionTableTest` | up to 51 × 10 OK; 11th transaction triggers ABEND; 52nd card triggers ABEND |
+| `FileGatewayTest` | All used (DD, op) combinations |
+| `PlainTextStatementBuilderTest` | Byte-exact for canonical input → 80-byte lines |
+| `HtmlStatementBuilderTest` | Byte-exact for canonical input → 100-byte lines |
+| `DispatchTableTest` | Each of the 5 dispatch points (open, close, read, etc.) |
+
+### 6.2 Smoke test
+
+`StatementCreatorTest` against a synthetic fixture: 2 customers × 2 cards × 3 transactions per card → 4 statements (or however the per-card grouping works); asserts file lengths and line counts.
+
+### 6.3 Golden-file integration test
+
+```
+1. cd cobol-reference && bash tools/regen-golden.sh
+   → cobc -x -free -fsign=EBCDIC CBSTM03P-B.cbl -o cbstm03p-b.so   # subprogram first
+   → cobc -x -free -fsign=EBCDIC CBSTM03P-A.cbl -L. -lcbstm03p-b
+   → COB_LS_FIXED=Y ./CBSTM03P-A
+   → cp {stmtfile.dat, htmlfile.dat} → fixtures/expected/
+
+2. mvn verify
+   → StatementGoldenFileEquivalenceIT
+       Files.mismatch(expected/stmtfile.dat, temp/stmtfile.dat) == -1L
+       Files.mismatch(expected/htmlfile.dat, temp/htmlfile.dat) == -1L
+```
+
+### 6.4 Synthetic edge-case fixtures
+
+| Fixture | Purpose |
+| ------- | ------- |
+| `single-card-single-tran/` | 1 card, 1 transaction → 1 statement, 1 HTML page |
+| `single-card-max-trans/` | 1 card, 10 transactions (TRAN-TBL fills exactly) |
+| `multi-card/` | 3 cards × 2 trans each → 3 statements |
+| `overflow-trans/` | 11 transactions on 1 card → ABEND |
+| `overflow-cards/` | 52 cards → ABEND |
+| `customer-with-special-chars/` | Customer name with `&`, `<`, `>` → byte-faithful in HTML (no escaping by COBOL — Java mirrors) |
+
+---
+
+## 7. Documents to be produced during implementation
+
+1. Append a "CBSTM03A + CBSTM03B — Statement Printer" section to
+   `app/java/batch_processing_workflow/README.md`.
+2. Append a CBSTM03A/B section to `HOW-TO-TEST.md` (note that GnuCOBOL
+   subprogram linkage requires building the subprogram with `-x -free`
+   and linking the main program against it).
+3. Add `docs/migration/CBSTM03A-CBSTM03B-java-architecture.md`.
+4. Update `docs/cobol/batch-programs.md` `CBSTM03A` and `CBSTM03B`
+   sections with pointers.
+5. The full STMTFILE and HTMLFILE byte-offset tables (from step 1 of
+   §4) land as an appendix to this document.
+
+---
+
+## 8. Risks and open decisions
+
+### 8.1 Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `ALTER` + `GO TO` accidentally introduces unintended behaviour in the Java port | `DispatchTableTest` covers every dispatch entry; the IT catches drift |
+| HTML special characters in customer names (`&`, `<`, `>`) — COBOL does not escape; we must not escape either | Test fixture exercises this; documented as faithful behaviour |
+| 2D OCCURS overflow silently misbehaves in Java | Explicit capacity check in `TransactionTable.put(...)` with `BatchAbendException(999)` |
+| `CBSTM03B` mock in tests doesn't model file-status `'10'` (EOF) correctly | `FileGatewayTest` exercises the EOF path on each DD |
+| Statement date / generation timestamp drift | `Db2Timestamp.useFixedClock(...)` injection in IT |
+| Mainframe-only PSA/TCB/TIOT walk produces SYSOUT lines that don't match Linux | IT does not check SYSOUT; only `STMTFILE` + `HTMLFILE` are byte-checked |
+| COBOL subprogram link in GnuCOBOL fails with `LD_LIBRARY_PATH` issues | Document `LD_LIBRARY_PATH=.` in `tools/run.sh` |
+
+### 8.2 Open decisions to confirm
+
+1. **`Stm03CustomerRecord` separate from `CustomerRecord`** —
+   defaulting yes (different copybook). Accept.
+2. **PSA/TCB/TIOT walk** stub-out — accept the Linux skip.
+3. **`FileGateway` API mirrors `CBSTM03B` 1:1** — accept (preserves
+   trace equivalence) or simplify to direct method calls (loses
+   trace equivalence, gains code clarity). Recommend mirror.
+4. **HTML escaping policy** — faithful to COBOL (no escaping). Accept.
+5. **Defaults in §3.2** — accept or override.
+6. **Scope locked** to `CBSTM03A` + `CBSTM03B` paired only — yes/no.
+
+---
+
+## 9. Out of scope for this migration
+
+- The `CREASTMT.JCL` upstream sort step that prepares
+  `(card-num, tran-id)`-keyed `TRNXFILE`. The portable oracle / Java
+  port assume the input fixture is already sorted.
+- Any production HTML rendering (browser display, CSS). The HTML
+  output is verbatim — the program does not emit a stylesheet or a
+  full `<head>`.
+- Online statement display. Only the batch FB-80 / FB-100 outputs.
+
+---
+
+## 10. Approval gate
+
+Confirm before implementation:
+
+1. **Per-program separation** — the pair is migrated together as one
+   commit chain. Accept or split.
+2. **`FileGateway` 1:1 mirror** of `CBSTM03B` — accept or simplify.
+3. **Defaults in §3.2** — accept or override.
+4. **Scope locked** to the pair only — yes/no.
+
+Once confirmed, work proceeds through steps 1–11 in §4.

--- a/docs/migration/CBTRN01C-to-java-plan.md
+++ b/docs/migration/CBTRN01C-to-java-plan.md
@@ -1,0 +1,373 @@
+# Migration Plan: `CBTRN01C.cbl` → Java
+
+**Source program:** `app/cbl/CBTRN01C.cbl` — the **daily-transaction reader / scaffold** of CardDemo. Reads each daily transaction, looks up its card on `XREFFILE`, and looks up the corresponding account on `ACCTFILE`. Emits SYSOUT only — does **not** post transactions or update balances. Effectively a reference / scaffold for the production poster `CBTRN02C`.
+
+**Driving JCL:** None in `app/jcl/`. The compiled load module is built but no nightly job invokes it. Treat this port as the low-risk testbed for the random-read store before `CBTRN02C` puts it under load.
+
+**Target location (mandatory):** `app/java/batch_processing_workflow/`
+
+**Goal:** A Java port that produces a SYSOUT capture **byte-for-byte identical** to the COBOL `DISPLAY` output on the same set of input fixtures, verified by an automated test that diffs against a GnuCOBOL-runnable reference build.
+
+This plan is purely a plan. **No code is written until approved.**
+
+---
+
+## 1. Source contract — what `CBTRN01C` does
+
+### 1.1 Inputs
+
+| DD name | COBOL `SELECT` | Org / Access | Record (copybook) | Notes |
+| ------- | -------------- | ------------ | ----------------- | ----- |
+| `DALYTRAN` | `DALYTRAN-FILE` | SEQUENTIAL | 350 bytes (`CVTRA06Y` — `DALYTRAN-RECORD`) | Driving file. Walked sequentially. |
+| `XREFFILE` | `XREF-FILE` | INDEXED / RANDOM | 50 bytes (`CVACT03Y` — `CARD-XREF-RECORD`) | Lookup keyed on `DALYTRAN-CARD-NUM`. |
+| `ACCTFILE` | `ACCOUNT-FILE` | INDEXED / RANDOM | 300 bytes (`CVACT01Y` — `ACCOUNT-RECORD`) | Lookup keyed on `XREF-ACCT-ID` from the previous read. |
+| `CUSTFILE` | `CUSTOMER-FILE` | INDEXED / RANDOM | 500 bytes (`CVCUS01Y`) | Opened but not referenced in the main loop in the current source — preserve OPEN/CLOSE for byte-equivalent SYSOUT. |
+| `CARDFILE` | `CARD-FILE` | INDEXED / RANDOM | 150 bytes (`CVACT02Y`) | Same — opened but not actively read in the main loop. |
+| `TRANFILE` | `TRANSACT-FILE` | INDEXED / RANDOM | 350 bytes (`CVTRA05Y`) | Same — opened but unused. |
+
+### 1.2 Outputs
+
+| Stream | COBOL verb | Format |
+| ------ | ---------- | ------ |
+| `SYSOUT` | Multiple `DISPLAY` | Banner + per-transaction lookup messages + status lines + final banner |
+
+**No file output.** The acceptance check is the SYSOUT capture.
+
+### 1.3 Algorithm (paragraph map)
+
+```
+PROCEDURE DIVISION:
+    DISPLAY 'START OF EXECUTION OF PROGRAM CBTRN01C'
+    PERFORM 0000-DALYTRAN-OPEN          OPEN INPUT  DALYTRAN-FILE
+    PERFORM 0100-CUSTFILE-OPEN          OPEN INPUT  CUSTFILE
+    PERFORM 0200-XREFFILE-OPEN          OPEN INPUT  XREF-FILE
+    PERFORM 0300-CARDFILE-OPEN          OPEN INPUT  CARD-FILE
+    PERFORM 0400-ACCTFILE-OPEN          OPEN INPUT  ACCOUNT-FILE
+    PERFORM 0500-TRANFILE-OPEN          OPEN INPUT  TRANSACT-FILE
+
+    LOOP UNTIL END-OF-FILE = 'Y':
+        PERFORM 1000-DALYTRAN-GET-NEXT
+        IF END-OF-FILE = 'N':
+            PERFORM 2000-LOOKUP-XREF
+                MOVE DALYTRAN-CARD-NUM TO FD-XREF-CARD-NUM
+                READ XREF-FILE INTO CARD-XREF-RECORD
+                    INVALID KEY: WS-XREF-READ-STATUS = 'N'; DISPLAY '*** invalid card '
+                    NOT INVALID KEY: DISPLAY 'XREF FOUND ' CARD-XREF-RECORD
+            IF WS-XREF-READ-STATUS = 'Y':
+                PERFORM 3000-READ-ACCOUNT
+                    MOVE XREF-ACCT-ID TO FD-ACCT-ID
+                    READ ACCOUNT-FILE INTO ACCOUNT-RECORD
+                        INVALID KEY: WS-ACCT-READ-STATUS = 'N'; DISPLAY '*** acct not found '
+                        NOT INVALID KEY: DISPLAY 'ACCOUNT FOUND ' ACCOUNT-RECORD
+
+    PERFORM 9000-9500-…-CLOSE          CLOSE all six files
+    DISPLAY 'END OF EXECUTION OF PROGRAM CBTRN01C'
+    GOBACK
+```
+
+(Exact `DISPLAY` strings must be lifted verbatim from the source — they go into the SYSOUT golden file.)
+
+### 1.4 Record layouts
+
+- `DALYTRAN-RECORD` (350 bytes) — `CVTRA06Y` is structurally a clone
+  of `CVTRA05Y` (`TRAN-RECORD`) used by `CBACT04C`. Field names are
+  prefixed `DALYTRAN-` instead of `TRAN-`. **Already covered** by the
+  `interest/` port's `TransactionRecord`.
+- `CARD-XREF-RECORD` (50 bytes) — already wrapped by
+  `interest.domain.CardXrefRecord`.
+- `ACCOUNT-RECORD` (300 bytes) — already wrapped by
+  `interest.domain.AccountRecord` for the 5 fields `interest`
+  needs; `account.domain.ExtractAccountRecord` (per the `CBACT01C`
+  plan) wraps all 11 fields. **Reuse `ExtractAccountRecord`** here.
+- `CUSTOMER-RECORD`, `CARD-RECORD`, `TRAN-RECORD` — opened but unused
+  in the main loop. The Java port mirrors that: open the file
+  (`Files.newInputStream`), do nothing with it, close. Or skip the
+  open entirely and document the deviation if it doesn't affect
+  SYSOUT — see §5.4.
+
+### 1.5 SYSOUT format
+
+The exact strings emitted by `CBTRN01C` are not as well-trodden as the readers' `DISPLAY <record>` pattern. Phase 1 of the plan-execution work is to dump the source's `DISPLAY` statements and tabulate every literal:
+
+```
+START OF EXECUTION OF PROGRAM CBTRN01C
+... per-record (success path) ...
+XREF FOUND <50-byte CARD-XREF-RECORD>
+ACCOUNT FOUND <300-byte ACCOUNT-RECORD>
+... per-record (xref miss) ...
+*** INVALID CARD NUMBER FOUND
+... per-record (acct miss) ...
+*** ACCOUNT RECORD NOT FOUND
+END OF EXECUTION OF PROGRAM CBTRN01C
+```
+
+A precise byte-by-byte transcription of every `DISPLAY` in `CBTRN01C.cbl` is the first deliverable of step 2 below — it is the contract the Java port must match.
+
+---
+
+## 2. Equivalence requirements (acceptance criteria)
+
+1. **`SYSOUT` capture** matches byte-for-byte against the GnuCOBOL oracle. The fixture must include at least one transaction that succeeds, one with an invalid card, and one with a missing account, so all three SYSOUT branches are exercised.
+
+**Acceptance test:** `diff -q sysout.cobol.txt sysout.java.txt` returns silently.
+
+**No timestamp injection needed** (no `FUNCTION CURRENT-DATE` calls in `CBTRN01C`).
+
+---
+
+## 3. Target architecture
+
+### 3.1 Layout
+
+```
+app/java/batch_processing_workflow/
+└── src/
+    ├── main/java/com/carddemo/batch/
+    │   ├── trnref/                                    ← new subpackage for CBTRN01C
+    │   │   ├── DailyTransactionReferenceReader.java   main(); mirrors PROCEDURE DIVISION
+    │   │   └── domain/
+    │   │       └── DalytranRecord.java                wraps CVTRA06Y (350 bytes)
+    │   ├── interest/                                  ← UNCHANGED; provides CardXrefRecord
+    │   ├── account/                                   ← UNCHANGED; provides ExtractAccountRecord
+    │   └── …                                          ← other packages unchanged
+    └── test/java/com/carddemo/batch/trnref/
+        ├── DalytranRecordRoundTripTest.java
+        ├── DailyTransactionReferenceReaderTest.java
+        └── DailyTransactionReferenceGoldenFileEquivalenceIT.java
+```
+
+The shared package promotion (per `CBACT02C`-plan §3.1) is assumed
+already done.  The new primitive this plan introduces is
+**`IndexedFileStore<K, V>`** in the shared `io` package — see §3.2.
+
+### 3.2 Decisions
+
+| Decision | Default | Why |
+| -------- | ------- | --- |
+| Java version | **Java 17** | Same module |
+| `XREFFILE` random read | **`IndexedFileStore<String, CardXrefRecord>` keyed on `XREF-CARD-NUM`** | First port to need a primary-key random read of `XREFFILE`; `CBACT04C` uses the AIX path instead. The store is loaded into a `Map<String, CardXrefRecord>` from `LINE SEQUENTIAL INPUT` — same pattern as `CBACT04C`'s `CardXrefFile` but keyed on a different field |
+| `ACCTFILE` random read | **`IndexedFileStore<Long, ExtractAccountRecord>` keyed on `ACCT-ID`** | Reuses the `account.domain.ExtractAccountRecord` from the `CBACT01C` plan (all 11 fields needed for `DISPLAY`) |
+| Lookup-miss handling | **`Optional.empty()`** + emit the same `*** INVALID …` line | `INVALID KEY` in COBOL is recoverable; do not throw |
+| SYSOUT capture | **`System.out` redirection** | Same pattern as readers |
+| Unused file opens (`CUSTFILE`, `CARDFILE`, `TRANFILE`) | **`Files.newByteChannel(... READ)` then immediate `close()`** | Faithful to the COBOL OPEN/CLOSE pair. Verify by inspecting SYSOUT — if no `DISPLAY` is tied to those opens, the deviation is invisible and we can collapse them; see §5.4 |
+
+### 3.3 New shared utility — `IndexedFileStore<K, V>`
+
+**Promote from `interest.io`'s `AccountFile` / `CardXrefFile` / `DisclosureGroupFile`** into a generic class:
+
+```java
+public final class IndexedFileStore<K, V> {
+    public static <K, V> IndexedFileStore<K, V> load(
+        Path inputPath,
+        int recordSize,
+        Function<byte[], V> recordCodec,
+        Function<V, K> keyExtractor
+    ) throws IOException;
+
+    public Optional<V> lookup(K key);
+
+    public V lookupOrAbend(K key, int abendCode);
+}
+```
+
+This becomes the canonical primary-key random-read primitive used by
+`CBTRN01C`, `CBTRN02C`, `CBTRN03C`, `CBSTM03B`, and the `CBEXPORT`
+input side. Its first caller is this plan; promotion happens here.
+
+### 3.4 Why a sequential-file GnuCOBOL port
+
+Same pattern as before. `CBTRN01P.cbl`:
+- All six SELECTs change from `INDEXED RANDOM` to `LINE SEQUENTIAL INPUT`.
+- Random reads (`READ … KEY IS … INVALID KEY`) become `SEARCH ALL` over in-memory tables loaded at OPEN time. The `INVALID KEY` block fires when `SEARCH ALL` exits via `WHEN OTHER`.
+- `DALYTRAN-FILE` was already sequential — no change.
+- All `DISPLAY` and ABEND paragraphs verbatim.
+
+---
+
+## 4. Step-by-step migration steps
+
+| # | Step | Acceptance |
+| - | ---- | ---------- |
+| 1 | Promote `interest/`'s `AccountFile`-style loaders to `IndexedFileStore<K, V>` in shared `io`. Refactor `interest/`'s callers to use the generic. | All existing `interest/` tests pass; behaviour unchanged |
+| 2 | Transcribe every `DISPLAY` literal in `CBTRN01C.cbl` to a Java string-constants class `Cbtrn01CMessages`. | Byte-by-byte match with the source `DISPLAY` literals |
+| 3 | Define `DalytranRecord` (350-byte wrapper; field accessors mirror `CVTRA06Y`). | Round-trip test parses a synthetic `dailytran.txt` fixture, byte-identical |
+| 4 | Implement `DailyTransactionReferenceReader.main()` — opens fixture inputs, loads xref+account stores, emits banners, loops over `DALYTRAN`, performs lookups, emits one of three SYSOUT lines per record. | Runs end-to-end on fixtures |
+| 5 | Write `cobol-reference/CBTRN01P.cbl` (sequential-only oracle as described in §3.4) plus the matching `tools/build.sh` and `tools/run.sh` patches. | `bash regen-golden.sh` produces `fixtures/expected/sysout.txt` |
+| 6 | Extend `tools/regen-golden.sh` to run `CBTRN01P` and capture SYSOUT. | Output captured |
+| 7 | Write unit tests for `DalytranRecord` round-trip and `IndexedFileStore` (lookup hit, lookup miss, lookup-miss-with-abend). | All pass |
+| 8 | Write `DailyTransactionReferenceGoldenFileEquivalenceIT`. | Passes |
+| 9 | Update `docs/cobol/batch-programs.md` `CBTRN01C` section pointer. | Pointer added |
+
+**Estimated effort:** ~1.5 engineering days. Most of the new work is in step 1 (promotion) and step 5 (portable oracle). Step 1's investment pays back across `CBTRN02C`, `CBTRN03C`, `CBSTM03B`, `CBEXPORT`, `CBIMPORT`.
+
+---
+
+## 5. Logic equivalency safeguards
+
+### 5.1 SYSOUT message strings
+
+Every COBOL `DISPLAY` string is part of the contract. A byte-for-byte mismatch on a banner literal is a regression. The `Cbtrn01CMessages` class lifts every literal verbatim and is the canonical source for the Java port. **Don't paraphrase.**
+
+### 5.2 Lookup-miss handling
+
+```cobol
+READ XREF-FILE INTO CARD-XREF-RECORD
+   INVALID KEY
+     MOVE 'N' TO WS-XREF-READ-STATUS
+     DISPLAY '*** INVALID CARD NUMBER FOUND'
+   NOT INVALID KEY
+     MOVE 'Y' TO WS-XREF-READ-STATUS
+     DISPLAY 'XREF FOUND ' CARD-XREF-RECORD
+END-READ
+```
+
+Java equivalent:
+
+```java
+Optional<CardXrefRecord> xref = xrefStore.lookup(cardNum);
+if (xref.isEmpty()) {
+    out.println(Cbtrn01CMessages.INVALID_CARD);
+} else {
+    out.write(Cbtrn01CMessages.XREF_FOUND_PREFIX);
+    out.write(xref.get().rawBytes());
+    out.write('\n');
+}
+```
+
+The Java port must **not** throw on lookup miss. `INVALID KEY` is the
+recoverable case. ABEND is reserved for unexpected file-status codes
+(open failure, I/O error), not for "not found".
+
+### 5.3 SYSOUT inheritance from sub-records
+
+`DISPLAY 'XREF FOUND ' CARD-XREF-RECORD` concatenates the literal `XREF FOUND ` (11 chars) with the 50-byte `CARD-XREF-RECORD` and appends `\n`. Total line: 11 + 50 + 1 = 62 bytes. Java emission must match this exactly — no extra space, no `toString()` formatting.
+
+### 5.4 Unused file opens
+
+The COBOL source opens `CUSTFILE`, `CARDFILE`, `TRANFILE` but the
+main loop never reads them. The Java port can either:
+
+(a) Open and close empty `IndexedFileStore`s for those files (faithful
+to source intent, but adds dead code).
+(b) Skip the opens entirely and **only** if no SYSOUT lines reference
+them (e.g. an OPEN failure would `DISPLAY '... OPEN FAILED ...'` then
+ABEND — but on the success path, OPEN/CLOSE are silent in COBOL).
+
+**Default to (b)**: skip the unused opens. The integration test
+proves SYSOUT-equivalence; if no `DISPLAY` mentions those files on
+the success path, the deviation is invisible. Document this in the
+plan and the architecture doc as the deliberate simplification.
+
+### 5.5 GnuCOBOL `SEARCH ALL` not-found fall-through
+
+The portable oracle uses `SEARCH ALL` over an in-memory table for the
+random-read replacement. `SEARCH ALL` falls through `WHEN OTHER` on a
+miss, with no built-in mapping to `INVALID KEY`. The portable
+program must explicitly set the file-status moral-equivalent on miss
+and execute the `INVALID KEY` body. This pattern is established in
+the `CBACT04C` portable oracle.
+
+---
+
+## 6. Test strategy
+
+### 6.1 Unit tests
+
+| Test class | Concern |
+| ---------- | ------- |
+| `DalytranRecordRoundTripTest` | parse → `rawBytes()` byte-identical for `dailytran.txt` |
+| `IndexedFileStoreTest` | hit, miss-with-`Optional.empty()`, miss-with-abend |
+| `Cbtrn01CMessagesTest` | every literal is exactly N bytes (no accidental whitespace) |
+
+### 6.2 Smoke test
+
+`DailyTransactionReferenceReaderTest` against a 3-record synthetic fixture:
+- record 1: card present in xref, account present → `XREF FOUND` + `ACCOUNT FOUND`
+- record 2: card not present → `INVALID CARD`
+- record 3: card present, account missing → `XREF FOUND` + `ACCOUNT NOT FOUND`
+
+Asserts the SYSOUT line count and the line ordering.
+
+### 6.3 Golden-file integration test
+
+```
+1. cd cobol-reference && bash tools/regen-golden.sh
+   → cobc -x -free -fsign=EBCDIC CBTRN01P.cbl
+   → COB_LS_FIXED=Y ./CBTRN01P > fixtures/expected/sysout.txt
+2. mvn verify
+   → DailyTransactionReferenceGoldenFileEquivalenceIT
+       Files.mismatch(expected/sysout.txt, temp/sysout.txt) == -1L
+```
+
+### 6.4 Synthetic edge-case fixtures
+
+| Fixture | Purpose |
+| ------- | ------- |
+| `all-success/` | All cards and accounts present; only `XREF FOUND` + `ACCOUNT FOUND` lines |
+| `all-xref-miss/` | All cards missing; only `INVALID CARD` lines |
+| `all-acct-miss/` | All cards present, all accounts missing; `XREF FOUND` + `ACCOUNT NOT FOUND` lines |
+| `mixed/` | One of each branch |
+| `empty/` | 0 daily transactions; banners only |
+
+---
+
+## 7. Documents to be produced during implementation
+
+1. Append a "CBTRN01C — Daily Transaction Reference Reader" section
+   to `app/java/batch_processing_workflow/README.md`.
+2. Append a CBTRN01C section to `HOW-TO-TEST.md`.
+3. Add `docs/migration/CBTRN01C-java-architecture.md` after
+   implementation.
+4. Update `docs/cobol/batch-programs.md` with the pointer.
+5. **Promotion changelog** — a new section in
+   `app/java/batch_processing_workflow/README.md` documenting the
+   `IndexedFileStore<K, V>` API, since this plan introduces it as a
+   shared utility.
+
+---
+
+## 8. Risks and open decisions
+
+### 8.1 Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `IndexedFileStore` API doesn't fit `CBTRN02C`'s `I-O` semantics → second refactor needed | Plan `IndexedFileStore` to handle both read-only and updatable cases; `CBTRN02C` plan §3 calls out the extension required (mutable `Map` + flush-back) |
+| SYSOUT literals drift between COBOL source and Java port → byte diff at unexpected offset | `Cbtrn01CMessages` test asserts every string length; review against `CBTRN01C.cbl` line by line |
+| Unused file opens deviation invalidates the SYSOUT golden file | The portable oracle keeps the OPEN/CLOSE for those files (so SYSOUT side-effects are matched); only the Java port drops them. The IT validates this is invisible |
+| `INVALID KEY` semantics misimplemented as exception → SYSOUT shows ABEND text | Cover with `IndexedFileStoreTest.lookupMissReturnsEmpty` and a synthetic fixture that exercises the miss path |
+
+### 8.2 Open decisions to confirm
+
+- **`IndexedFileStore` promotion** — accept (recommended) or build
+  this plan's stores ad-hoc (defer the promotion to `CBTRN02C`).
+- **Skip unused file opens** — default (b). Confirm.
+- **`DalytranRecord` vs reuse `interest.domain.TransactionRecord`** —
+  `CVTRA06Y` and `CVTRA05Y` are the same shape but different field
+  names. Default: new `DalytranRecord` (the prefixes matter for
+  readability and consistency with the source). If you'd rather alias
+  `TransactionRecord`, flag it.
+
+---
+
+## 9. Out of scope for this migration
+
+- Production posting (that's `CBTRN02C`).
+- Validation logic (also `CBTRN02C`).
+- File output of any kind.
+
+---
+
+## 10. Approval gate
+
+Confirm before implementation:
+
+1. **`IndexedFileStore<K, V>` promotion** as part of step 1 — accept
+   or defer.
+2. **Skipping unused file opens** — accept or require faithful OPEN/CLOSE.
+3. **New `DalytranRecord`** vs aliasing `TransactionRecord` — accept
+   or override.
+4. **Defaults in §3.2** — accept or override.
+5. **Scope locked** to `CBTRN01C` only — yes/no.
+
+Once confirmed, work proceeds through steps 1–9 in §4.

--- a/docs/migration/CBTRN02C-to-java-plan.md
+++ b/docs/migration/CBTRN02C-to-java-plan.md
@@ -1,0 +1,482 @@
+# Migration Plan: `CBTRN02C.cbl` → Java
+
+**Source program:** `app/cbl/CBTRN02C.cbl` — the **daily transaction poster** of CardDemo. The production-grade counterpart to the `CBTRN01C` scaffold. Validates each row of the daily-transaction PS against the cross-reference and account masters; for valid rows, updates the running transaction-category balance, updates the account current balance and cycle counters, and writes the transaction into the master `TRANFILE`. Validation failures go to `DALYREJS` (a GDG) with a structured 80-byte trailer. Sets `RETURN-CODE = 4` if any rejects were produced.
+
+**Driving JCL:** `app/jcl/POSTTRAN.jcl` (single step `STEP15`).
+
+**Target location (mandatory):** `app/java/batch_processing_workflow/`
+
+**Goal:** A Java port that produces **byte-for-byte identical output** to the COBOL run — across all four output artifacts (`TRANFILE`, the `ACCTFILE` rewrite, the `TCATBALF` rewrite, `DALYREJS`) plus matching `RETURN-CODE` — verified by an automated test that diffs against a GnuCOBOL-runnable reference build.
+
+This plan is purely a plan. **No code is written until approved.**
+
+---
+
+## 1. Source contract — what `CBTRN02C` does
+
+### 1.1 Inputs
+
+| DD name | COBOL `SELECT` | Org / Access | Record (copybook) | Notes |
+| ------- | -------------- | ------------ | ----------------- | ----- |
+| `DALYTRAN` | `DALYTRAN-FILE` | SEQUENTIAL | 350 bytes (`CVTRA06Y`) | Driving file. |
+| `XREFFILE` | `XREF-FILE` | INDEXED / RANDOM | 50 bytes (`CVACT03Y`) | Lookup keyed on `DALYTRAN-CARD-NUM`. |
+
+### 1.2 Outputs (multiple paths, one program)
+
+| DD name | COBOL `SELECT` | Org / Access | Record | Notes |
+| ------- | -------------- | ------------ | ------ | ----- |
+| `TRANFILE` | `TRANSACT-FILE` | INDEXED / RANDOM, OPENED `OUTPUT` | 350 bytes (`CVTRA05Y`) | Wholesale rewrite of master. Note: opened `OUTPUT` not `I-O` — the existing TRANFILE is replaced. |
+| `ACCTFILE` | `ACCOUNT-FILE` | INDEXED / RANDOM, OPENED `I-O` | 300 bytes (`CVACT01Y`) | Random `READ` + `REWRITE`-in-place. |
+| `TCATBALF` | `TCATBAL-FILE` | INDEXED / RANDOM, OPENED `I-O` | 50 bytes (`CVTRA01Y`) | Random `READ`; `WRITE` (new key) or `REWRITE` (existing key). |
+| `DALYREJS` | `DALYREJS-FILE` | SEQUENTIAL OUTPUT (GDG `+1`) | 430 bytes (350-byte rejected `DALYTRAN` + 80-byte trailer) | One per validation-failed transaction. |
+| `RETURN-CODE` | (special register) | n/a | int | `0` if no rejects, `4` if any rejects. |
+| `SYSOUT` | n/a | text | various | Banners, "TCATBAL not found, creating" message, transaction/reject counts. |
+
+### 1.3 Algorithm (paragraph map)
+
+```
+PROCEDURE DIVISION:
+    DISPLAY 'START OF EXECUTION OF PROGRAM CBTRN02C'
+    OPEN all 6 files (paragraphs 0000–0500). ABEND on non-'00'.
+
+    LOOP UNTIL END-OF-FILE = 'Y':
+        PERFORM 1000-DALYTRAN-GET-NEXT
+        IF END-OF-FILE = 'N':
+            ADD 1 TO WS-TRANSACTION-COUNT
+            MOVE 0 TO WS-VALIDATION-FAIL-REASON
+            MOVE SPACES TO WS-VALIDATION-FAIL-REASON-DESC
+            PERFORM 1500-VALIDATE-TRAN:
+                1500-A-LOOKUP-XREF (READ XREF; INVALID KEY → reason=100)
+                IF reason=0: 1500-B-LOOKUP-ACCT
+                    READ ACCOUNT
+                    INVALID KEY → reason=101
+                    NOT INVALID KEY:
+                        WS-TEMP-BAL = ACCT-CURR-CYC-CREDIT - ACCT-CURR-CYC-DEBIT + DALYTRAN-AMT
+                        IF ACCT-CREDIT-LIMIT < WS-TEMP-BAL: reason=102 'OVERLIMIT TRANSACTION'
+                        IF ACCT-EXPIRAION-DATE < DALYTRAN-ORIG-TS(1:10): reason=103 'TRANSACTION RECEIVED AFTER ACCT EXPIRATION'
+            IF reason = 0: PERFORM 2000-POST-TRANSACTION
+            ELSE:           ADD 1 TO WS-REJECT-COUNT; PERFORM 2500-WRITE-REJECT-REC
+
+    CLOSE all 6 files (9000–9500). ABEND on non-'00'.
+    DISPLAY 'TRANSACTIONS PROCESSED :' WS-TRANSACTION-COUNT
+    DISPLAY 'TRANSACTIONS REJECTED  :' WS-REJECT-COUNT
+    IF WS-REJECT-COUNT > 0: MOVE 4 TO RETURN-CODE
+    DISPLAY 'END OF EXECUTION OF PROGRAM CBTRN02C'
+    GOBACK
+```
+
+**`2000-POST-TRANSACTION`** — for each valid transaction:
+
+```
+MOVE every DALYTRAN-* field to corresponding TRAN-* field
+PERFORM Z-GET-DB2-FORMAT-TIMESTAMP    → TRAN-PROC-TS = current DB2 timestamp
+PERFORM 2700-UPDATE-TCATBAL:
+    READ TCATBAL by (acct, type, cat).
+    INVALID KEY:
+        2700-A-CREATE-TCATBAL-REC: INITIALIZE; populate; ADD DALYTRAN-AMT; WRITE
+    NOT INVALID KEY (status '00'):
+        2700-B-UPDATE-TCATBAL-REC: ADD DALYTRAN-AMT; REWRITE
+PERFORM 2800-UPDATE-ACCOUNT-REC:
+    ADD DALYTRAN-AMT TO ACCT-CURR-BAL
+    IF DALYTRAN-AMT >= 0: ADD TO ACCT-CURR-CYC-CREDIT
+    ELSE:                  ADD TO ACCT-CURR-CYC-DEBIT
+    REWRITE ACCOUNT-RECORD
+        INVALID KEY → reason=109 'ACCOUNT RECORD NOT FOUND'   (note: silent — does not write reject)
+PERFORM 2900-WRITE-TRANSACTION-FILE: WRITE TRAN-RECORD to TRANFILE
+```
+
+### 1.4 `Z-GET-DB2-FORMAT-TIMESTAMP`
+
+Identical to `CBACT04C`'s helper — produces `YYYY-MM-DD-HH.MI.SS.MIL0000` (26 chars) from `FUNCTION CURRENT-DATE`. **Reuse `interest.util.Db2Timestamp` directly.**
+
+### 1.5 Validation reasons → trailer reason codes
+
+| Reason | Description (`PIC X(76)` truncated/padded) | Source |
+| ------ | ------------------------------------------- | ------ |
+| 100 | `INVALID CARD NUMBER FOUND` | XREF lookup miss |
+| 101 | `ACCOUNT RECORD NOT FOUND` | ACCT lookup miss |
+| 102 | `OVERLIMIT TRANSACTION` | Credit limit exceeded |
+| 103 | `TRANSACTION RECEIVED AFTER ACCT EXPIRATION` | Expiration check |
+| 109 | `ACCOUNT RECORD NOT FOUND` | REWRITE failure (silent — never reaches `WRITE-REJECT-REC`) |
+
+### 1.6 Reject record layout — 430 bytes total
+
+```
++------------------+  +-----------------------+
+| 350-byte         |  | 80-byte trailer       |
+| original DALYTRAN|  | reason (4 digits) +   |
+| record           |  | description (76 X)    |
++------------------+  +-----------------------+
+```
+
+| Trailer offset | Len | Field | PIC | Notes |
+| -------------- | --- | ----- | --- | ----- |
+| 0 | 4 | `WS-VALIDATION-FAIL-REASON` | `PIC 9(04)` | Zero-padded, e.g. `0102` |
+| 4 | 76 | `WS-VALIDATION-FAIL-REASON-DESC` | `PIC X(76)` | Right-padded with spaces |
+
+### 1.7 Numeric formats
+
+All decimal fields are zoned `S9(n)V99` — the same shape used by `CBACT04C`. **Reuse `interest.io.ZonedDecimalCodec`** as-is.
+
+| Field | PIC | Notes |
+| ----- | --- | ----- |
+| `DALYTRAN-AMT` | `S9(09)V99` | 11 chars zoned |
+| `ACCT-CURR-BAL` | `S9(10)V99` | 12 chars zoned |
+| `ACCT-CREDIT-LIMIT` | `S9(10)V99` | 12 chars zoned |
+| `ACCT-CURR-CYC-CREDIT` | `S9(10)V99` | 12 chars zoned |
+| `ACCT-CURR-CYC-DEBIT` | `S9(10)V99` | 12 chars zoned |
+| `WS-TEMP-BAL` | `S9(09)V99` | working-storage; intermediate for the limit check |
+| `TRAN-CAT-BAL` | `S9(09)V99` | 11 chars zoned in TCATBAL |
+
+### 1.8 Compute behaviour
+
+`COMPUTE WS-TEMP-BAL = ACCT-CURR-CYC-CREDIT - ACCT-CURR-CYC-DEBIT + DALYTRAN-AMT` has **no `ROUNDED` clause** → result truncates toward zero on the destination scale of 2. Same as `CBACT04C` rule. Java equivalent: `BigDecimal.add` + `subtract` then `setScale(2, RoundingMode.DOWN)`.
+
+`ADD DALYTRAN-AMT TO ACCT-CURR-BAL` and the cycle-credit/debit additions are also unrounded. The destination scales are 2 already; truncation only matters if amounts are introduced at a different scale. Defensively use `.setScale(2, RoundingMode.DOWN)` after every add.
+
+---
+
+## 2. Equivalence requirements (acceptance criteria)
+
+Five artifacts must match byte-for-byte between the GnuCOBOL oracle run and the Java port run on the same input fixture:
+
+1. **`TRANFILE` output** (350-byte records).
+2. **Final state of `ACCTFILE`** (300-byte records).
+3. **Final state of `TCATBALF`** (50-byte records).
+4. **`DALYREJS` output** (430-byte records).
+5. **`RETURN-CODE`** (integer).
+
+Plus a sixth, informational, equivalence:
+
+6. **SYSOUT** — banners, the per-create `TCATBAL record not found...` notes, transaction count, reject count, and final banner. **Treat as best-effort byte equivalence**, not a hard fail (timestamp text is timestamp-injected; counts are deterministic).
+
+**Acceptance test:** five `Files.mismatch(expected, actual) == -1L` checks plus an `assertEquals(expectedReturnCode, actualReturnCode)`.
+
+**Two known sources of divergence to neutralize:**
+
+- **`TRAN-PROC-TS` timestamps** — pull from `FUNCTION CURRENT-DATE` per
+  posted transaction. Must inject a fixed `Clock` on both sides.
+  COBOL side: compile-time `-DTEST_FIXED_TS=…` switch in
+  `Z-GET-DB2-FORMAT-TIMESTAMP`. Java side:
+  `Db2Timestamp.useFixedClock(...)` from `interest/util`, called in
+  `@BeforeAll`.
+- **`DALYTRAN-ORIG-TS`** — read from input fixture verbatim. Already
+  deterministic.
+
+**No PARM-driven divergence** — `CBTRN02C` does not consume a JCL `PARM`.
+
+---
+
+## 3. Target architecture
+
+### 3.1 Layout
+
+```
+app/java/batch_processing_workflow/
+└── src/
+    ├── main/java/com/carddemo/batch/
+    │   ├── posting/                                         ← new subpackage for CBTRN02C
+    │   │   ├── DailyTransactionPoster.java                  main(); mirrors PROCEDURE DIVISION
+    │   │   ├── domain/
+    │   │   │   ├── DalytranRecord.java                      (reuse from CBTRN01C plan if available; else introduced here)
+    │   │   │   └── ValidationFailure.java                   record { int reason; String description; }
+    │   │   └── io/
+    │   │       ├── DalytranReader.java                      sequential 350-byte reader
+    │   │       ├── TransactFileWriter.java                  writes to TRANFILE.dat (sorted on TRAN-ID before flush)
+    │   │       ├── DailyRejectsWriter.java                  appends 430-byte reject records
+    │   │       └── (uses shared) MutableIndexedFileStore    reads + REWRITE-equivalent flush
+    │   ├── interest/                                        ← UNCHANGED; provides Db2Timestamp + ZonedDecimalCodec
+    │   ├── account/                                         ← UNCHANGED
+    │   └── …                                                ← other packages unchanged
+    └── test/java/com/carddemo/batch/posting/
+        ├── DalytranRecordRoundTripTest.java
+        ├── ValidationLogicTest.java                         covers the three reason-code branches deterministically
+        ├── PostingArithmeticTest.java                       BigDecimal RoundingMode.DOWN
+        ├── DailyTransactionPosterTest.java                  end-to-end on a synthetic fixture
+        └── PostingGoldenFileEquivalenceIT.java              diff vs. GnuCOBOL oracle for all 4 output files
+```
+
+### 3.2 Decisions
+
+| Decision | Default | Why |
+| -------- | ------- | --- |
+| Java version | **Java 17** | Same module |
+| `XREFFILE` | **`IndexedFileStore<String, CardXrefRecord>`** (read-only, from `CBTRN01C` plan) | Random read by `XREF-CARD-NUM`. Already loaded. |
+| `ACCTFILE` (I-O) | **`MutableIndexedFileStore<Long, ExtractAccountRecord>`** | NEW: extends `IndexedFileStore` with mutable values + ordered flush-back to `LINE SEQUENTIAL OUTPUT`. The Java equivalent of `OPEN I-O` + `REWRITE`. |
+| `TCATBALF` (I-O) | **`MutableIndexedFileStore<TcatBalKey, TransactionCategoryBalanceRecord>`** | Same pattern. The composite key (acct, type, cat) is a small `record` value type. |
+| `TRANFILE` | **`OPEN OUTPUT` simulated** — Java buffers writes in-memory, then writes them sorted on `TRAN-ID` to `TRANFILE.dat` | Real VSAM `OPEN OUTPUT INDEXED` requires keys in ascending order; the COBOL code writes in DALYTRAN order, which means real VSAM would ABEND on out-of-order keys. The portable oracle and Java port both write sequentially; the IT compares them at the byte level, so any sort divergence is caught |
+| `DALYREJS` | **Sequential append-only writer** | 430-byte records (350 + 80) |
+| Decimal arithmetic | **`BigDecimal` with `setScale(2, RoundingMode.DOWN)`** | Same as `CBACT04C` |
+| Timestamp injection | **`Db2Timestamp.useFixedClock(Instant)`** from `interest.util` | Reuse |
+| `RETURN-CODE = 4` | **`System.exit(4)` from `main()` if rejectCount > 0** | Mirrors COBOL convention |
+| Map ordering | **`LinkedHashMap`** for ACCTFILE + TCATBAL | Preserves insertion order on flush, mimicking VSAM's key-order rewrite (silent killer #5/#8) |
+
+### 3.3 New shared utility: `MutableIndexedFileStore<K, V>`
+
+Promote from `interest.io.AccountFile` (which already implements this
+pattern for `OPEN I-O` of `ACCOUNT-FILE` in `CBACT04C`). The
+generalised contract:
+
+```java
+public final class MutableIndexedFileStore<K, V> {
+    public static <K, V> MutableIndexedFileStore<K, V> load(...);
+
+    public Optional<V> lookup(K key);
+    public V lookupOrAbend(K key, int abendCode);
+
+    public void put(K key, V value);     // covers WRITE (new key) and REWRITE (existing key)
+
+    public void flush(Path outputPath);  // dump the LinkedHashMap in insertion order
+}
+```
+
+This becomes the canonical `OPEN I-O` primitive used by `CBTRN02C` and
+later `CBSTM03B`.
+
+### 3.4 Why a sequential-file GnuCOBOL port
+
+Following the established pattern, `CBTRN02P.cbl`:
+
+- All four INDEXED files (`XREF-FILE`, `ACCOUNT-FILE`, `TCATBAL-FILE`,
+  `TRANSACT-FILE`) change from `INDEXED RANDOM` to:
+  - On open: read entire file into a `WORKING-STORAGE` table via
+    `LINE SEQUENTIAL INPUT`, store with `OCCURS DEPENDING ON`.
+  - Random reads (`READ … KEY IS … INVALID KEY`) become `SEARCH ALL`
+    on the in-memory table; `WHEN OTHER` simulates `INVALID KEY`.
+  - `REWRITE` becomes a table update.
+  - `WRITE` (for `2700-A-CREATE-TCATBAL-REC`) becomes a table append.
+  - On close: dump the table back as `LINE SEQUENTIAL OUTPUT`.
+- For `TRANSACT-FILE`, "OPEN OUTPUT" is naturally sequential — no change
+  beyond `INDEXED` → `LINE SEQUENTIAL OUTPUT`.
+- `DALYTRAN-FILE` was already sequential — `LINE SEQUENTIAL INPUT`.
+- `DALYREJS-FILE` was already sequential — `LINE SEQUENTIAL OUTPUT`.
+- All business logic paragraphs (`1500*`, `2000`, `2500`, `2700*`,
+  `2800`, `2900`, `Z-GET-DB2-FORMAT-TIMESTAMP`, `9999`) **copied
+  verbatim**.
+- `Z-GET-DB2-FORMAT-TIMESTAMP` is replaced for tests by a
+  `-DTEST_FIXED_TS=…` switch (same pattern as the `CBACT04C`
+  portable oracle).
+
+---
+
+## 4. Step-by-step migration steps
+
+| # | Step | Acceptance |
+| - | ---- | ---------- |
+| 1 | Promote `MutableIndexedFileStore<K, V>` into shared `io` (lift from `interest.io.AccountFile`). Refactor `interest/`'s `AccountFile` to be a thin wrapper. | All existing `interest/` tests pass; behaviour unchanged |
+| 2 | Define `DalytranRecord` (350-byte wrapper, 18 fields) — reuse from `CBTRN01C` plan if already implemented; else implement here. | Round-trip parses `dailytran.txt`, byte-identical |
+| 3 | Define a `TcatBalKey` record `{ long acctId; String typeCd; int catCd; }` for the composite key. | `equals`/`hashCode` test |
+| 4 | Define a `ValidationFailure` record `{ int reason; String description; }` and a `Validator` class with `validate(DalytranRecord, IndexedFileStore<String, CardXrefRecord>, MutableIndexedFileStore<Long, ExtractAccountRecord>) → Optional<ValidationFailure>`. Cover reasons 100, 101, 102, 103. | `ValidationLogicTest` passes for all four branches |
+| 5 | Implement `TransactFileWriter` (sequential 350-byte writer; mirrors `2900-WRITE-TRANSACTION-FILE`). | Smoke test |
+| 6 | Implement `DailyRejectsWriter` (sequential 430-byte writer; mirrors `2500-WRITE-REJECT-REC`). | Smoke test |
+| 7 | Implement `DailyTransactionPoster.main()`. Wire the validator, the timestamp injection, the four files, the SYSOUT counters, the RETURN-CODE. | Runs end-to-end on the project fixtures |
+| 8 | Write `cobol-reference/CBTRN02P.cbl` (sequential-only oracle as in §3.4) plus the build/run/regen scripts including `-DTEST_FIXED_TS=…`. | `bash regen-golden.sh` produces all 4 expected files |
+| 9 | Write the unit tests in §6. | All pass |
+| 10 | Write `PostingGoldenFileEquivalenceIT` — runs `DailyTransactionPoster.main()` then asserts byte-equivalence on all 4 output files plus `RETURN-CODE`. | Passes |
+| 11 | Update `docs/cobol/batch-programs.md` `CBTRN02C` section pointer. | Pointer added |
+
+**Estimated effort:** ~3–4 focused engineering days. The biggest unknowns are step 1 (promotion + refactor of `AccountFile`) and step 8 (sequential portable oracle for the I-O files).
+
+---
+
+## 5. Logic equivalency safeguards
+
+### 5.1 LinkedHashMap insertion-order on REWRITE
+
+`ACCTFILE` and `TCATBALF` are opened `I-O`. The COBOL code writes them back in **VSAM key order** at flush. The portable oracle reads them via `LINE SEQUENTIAL` and writes them back via `LINE SEQUENTIAL OUTPUT` — preserving **input order**. The Java port must use `LinkedHashMap` (or an explicit insertion-order list) and flush in that order. Any HashMap regression silently re-orders the output and breaks the IT (silent killer #5/#8 from the playbook).
+
+### 5.2 New-record ordering for TCATBAL
+
+`2700-A-CREATE-TCATBAL-REC` writes a brand-new record with a key that didn't previously exist. The portable oracle appends it to the end of the in-memory table. The Java `MutableIndexedFileStore.put(newKey, value)` must also append (which `LinkedHashMap.put` does). On flush, the new record appears at the end of `TCATBAL.dat`.
+
+### 5.3 Validation-fail-reason zero-pad
+
+`WS-VALIDATION-FAIL-REASON PIC 9(04)` zero-pads to 4 digits when written into the trailer. Java: `String.format("%04d", reason)`.
+
+### 5.4 Validation description right-pad
+
+`WS-VALIDATION-FAIL-REASON-DESC PIC X(76)` right-pads with spaces if the literal is shorter. The 4 known reason descriptions:
+
+| Reason | Description literal | Bytes in literal | Trailing spaces to 76 |
+| ------ | ------------------- | ----------------- | --------------------- |
+| 100 | `INVALID CARD NUMBER FOUND` | 25 | 51 |
+| 101 | `ACCOUNT RECORD NOT FOUND` | 24 | 52 |
+| 102 | `OVERLIMIT TRANSACTION` | 21 | 55 |
+| 103 | `TRANSACTION RECEIVED AFTER ACCT EXPIRATION` | 42 | 34 |
+
+Java: use `FixedWidthFormat.writeText(buf, 4, 76, description)` with right-padding.
+
+### 5.5 `ACCT-EXPIRAION-DATE` string compare
+
+```cobol
+IF ACCT-EXPIRAION-DATE >= DALYTRAN-ORIG-TS (1:10)
+```
+
+This is a **string** comparison (not a date comparison) — both sides are `PIC X(10)`. As long as both follow `YYYY-MM-DD`, lexicographic order matches chronological order. Java: `expirationDate.compareTo(origTs.substring(0, 10)) >= 0`. **Do not parse to `LocalDate`** — that would risk silent format normalisation.
+
+### 5.6 Timestamp injection
+
+```java
+@BeforeAll
+static void freezeTime() {
+    Db2Timestamp.useFixedClock(
+        Clock.fixed(Instant.parse("2025-04-29T12:00:00Z"), ZoneOffset.UTC));
+}
+```
+
+For the COBOL oracle, `tools/build.sh` compiles with
+`-DTEST_FIXED_TS='2025-04-29-12.00.00.000000'`. Both sides write the
+same 26-byte string to `TRAN-PROC-TS`.
+
+### 5.7 First-record / EOF flush guards
+
+Unlike `CBACT04C`, `CBTRN02C` has no first-record guard or EOF-final-flush. The mainline loop does not run `2700-UPDATE-TCATBAL` on EOF — it stops when the read returns status `'10'`. No special handling required.
+
+### 5.8 Silent reason-109 path (REWRITE failure)
+
+`2800-UPDATE-ACCOUNT-REC` sets `WS-VALIDATION-FAIL-REASON=109` on `INVALID KEY` from `REWRITE` — but the surrounding mainline never re-checks the reason after `2000-POST-TRANSACTION` returns. Reason 109 is therefore **silent**: no reject record, no count increment. Java must replicate this: log a warning, do not write to `DALYREJS`, do not increment the reject counter. (This is almost certainly a bug in the original, but it's the contract.)
+
+### 5.9 Cycle credit / cycle debit signedness
+
+```cobol
+IF DALYTRAN-AMT >= 0
+    ADD DALYTRAN-AMT TO ACCT-CURR-CYC-CREDIT
+ELSE
+    ADD DALYTRAN-AMT TO ACCT-CURR-CYC-DEBIT
+END-IF
+```
+
+For a negative amount, COBOL adds the negative value to `ACCT-CURR-CYC-DEBIT`, so the debit field accumulates **negatively**. This is unintuitive (one might expect `ABS(DALYTRAN-AMT)` to be added to the debit), but it is the program's behaviour. The Java port must replicate it: `acctCurrCycDebit = acctCurrCycDebit.add(dalytranAmt)` (no abs).
+
+---
+
+## 6. Test strategy
+
+### 6.1 Unit tests
+
+| Test class | Concern |
+| ---------- | ------- |
+| `DalytranRecordRoundTripTest` | parse → `rawBytes()` byte-identical for `dailytran.txt` |
+| `MutableIndexedFileStoreTest` | load, lookup, put-as-update, put-as-insert, flush preserves insertion order |
+| `ValidationLogicTest` | All 4 reason codes (100, 101, 102, 103); valid pass-through |
+| `PostingArithmeticTest` | Decimal `setScale(2, DOWN)` truncation; cycle credit/debit signedness; over-limit boundary (`==` vs `>`) |
+| `RejectRecordLayoutTest` | 430-byte exact layout: 350 (verbatim DALYTRAN) + 4 (zero-padded reason) + 76 (right-padded description) |
+
+### 6.2 Synthetic edge-case fixtures
+
+| Fixture | Purpose |
+| ------- | ------- |
+| `all-pass/` | 10 valid transactions; 0 rejects; `RETURN-CODE = 0` |
+| `xref-miss/` | 1 transaction with unknown card → reason 100, 1 reject |
+| `acct-miss/` | 1 with known card but unknown account → reason 101 |
+| `over-limit/` | 1 that pushes balance over `ACCT-CREDIT-LIMIT` → reason 102 |
+| `expired/` | 1 where `DALYTRAN-ORIG-TS(1:10) > ACCT-EXPIRAION-DATE` → reason 103 |
+| `tcatbal-create/` | Valid transaction whose `(acct, type, cat)` key is not in `TCATBAL` → exercises `2700-A-CREATE` |
+| `tcatbal-update/` | Valid transaction whose key already exists → exercises `2700-B-UPDATE` |
+| `negative-amount/` | Valid negative-amount transaction → exercises `ACCT-CURR-CYC-DEBIT` branch |
+| `mixed/` | 5 valid + 3 reject + 2 silent-109 → 5 in `TRANFILE`, 3 in `DALYREJS`, `RETURN-CODE = 4`, `WS-REJECT-COUNT = 3` |
+
+### 6.3 Round-trip integration tests
+
+For each input file (`DALYTRAN`, `XREFFILE`, `ACCTFILE` initial,
+`TCATBALF` initial):
+
+```
+parse(fixtures/input/foo.txt) → record[]
+records.forEach(format) → bytes[]
+assert bytes equals original file bytes
+```
+
+This catches encoding bugs without running business logic.
+
+### 6.4 Golden-file integration test
+
+```
+1. cd cobol-reference && bash tools/regen-golden.sh
+   → cobc -x -free -fsign=EBCDIC -DTEST_FIXED_TS='…' CBTRN02P.cbl
+   → COB_LS_FIXED=Y ./CBTRN02P
+   → copy {transact.dat, acctdata.out, tcatbal.out, dalyrejs.dat} → fixtures/expected/
+
+2. mvn verify
+   → PostingGoldenFileEquivalenceIT:
+       • setup: copy fixtures/input/ to temp dir
+       • Db2Timestamp.useFixedClock(...)
+       • DailyTransactionPoster.run(temp)            // returns int returnCode
+       • assertReturnCodeMatches(expected)
+       • Files.mismatch(expected/transact.dat,  temp/transact.dat)  == -1L
+       • Files.mismatch(expected/acctdata.out,  temp/acctdata.out)  == -1L
+       • Files.mismatch(expected/tcatbal.out,   temp/tcatbal.out)   == -1L
+       • Files.mismatch(expected/dalyrejs.dat,  temp/dalyrejs.dat)  == -1L
+```
+
+---
+
+## 7. Documents to be produced during implementation
+
+1. Append a "CBTRN02C — Daily Transaction Poster" section to
+   `app/java/batch_processing_workflow/README.md`.
+2. Append a CBTRN02C section to `HOW-TO-TEST.md`.
+3. Add `docs/migration/CBTRN02C-java-architecture.md` after
+   implementation.
+4. Update `docs/cobol/batch-programs.md` `CBTRN02C` section pointer.
+5. Document the new `MutableIndexedFileStore<K, V>` API alongside
+   `IndexedFileStore<K, V>` (introduced in `CBTRN01C` plan) in the
+   shared `io` package's javadoc.
+6. Document the silent-reason-109 quirk in the
+   `DailyTransactionPoster` class doc-comment so future maintainers
+   don't "fix" it.
+
+---
+
+## 8. Risks and open decisions
+
+### 8.1 Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `LinkedHashMap` regression silently reorders REWRITEs | Both `MutableIndexedFileStoreTest` and the IT catch this. Add a doc-comment on `MutableIndexedFileStore` warning against `HashMap`. |
+| Silent reason-109 path obscures failures in production | Document as known. Add a `WARN`-level log so operators see it even if no reject is written. The log doesn't affect byte-equivalence (it goes to a separate stream). |
+| `RoundingMode.HALF_UP` slips into the temp-balance computation | `PostingArithmeticTest` covers boundary values |
+| Timestamp injection forgotten in CLI mode | Expose `--ts=YYYY-MM-DD-HH.MI.SS.MIL000000` flag on `DailyTransactionPoster.main()` |
+| `WRITE OUTPUT` to `TRANFILE` for an INDEXED VSAM file would normally require ascending keys; out-of-order writes ABEND | Both the portable oracle and the Java port write sequentially in DALYTRAN order. The IT proves Java≡oracle, not Java≡real-VSAM. Document this is a known divergence from production VSAM. |
+| `TCATBAL` create-vs-update file-status handling is brittle (`'00' OR '23'`) | `MutableIndexedFileStoreTest` covers both branches |
+| `DALYREJS` GDG semantics not modelled | Plain sequential append. The mainframe creates `+1` GDG generation in JCL; in Java the file path is just `dalyrejs.dat`. Document the deviation. |
+
+### 8.2 Open decisions to confirm
+
+1. **`MutableIndexedFileStore` promotion** as part of step 1 — accept
+   or defer.
+2. **Silent reason-109 fidelity** — replicate verbatim (no reject
+   written, no count increment) or treat as a bug to be fixed
+   (write a 109-reject). Recommend faithful replication; flag if you
+   want different behaviour.
+3. **`TRAN-PROC-TS` timestamp source** — `Db2Timestamp.useFixedClock`
+   in tests, wall clock in CLI runs (with `--ts=` override) — accept?
+4. **`RETURN-CODE = 4` mapping** — `System.exit(4)` from `main`. OK?
+5. **Defaults in §3.2** — accept or override.
+6. **Scope locked** to `CBTRN02C` only — yes/no.
+
+---
+
+## 9. Out of scope for this migration
+
+- Real VSAM `OPEN OUTPUT` semantics (out-of-order key ABEND).
+- GDG generation increment for `DALYREJS`.
+- The `CSUTLDPY`/`CSUTLDTC` date validation flow (this program doesn't
+  use it).
+- Online transaction-entry (`COTRN0xC`).
+- The `app/scheduler/` automation triggers.
+
+---
+
+## 10. Approval gate
+
+Confirm before implementation:
+
+1. **`MutableIndexedFileStore<K, V>` promotion** in step 1 — accept
+   or defer.
+2. **Silent-109 fidelity** — accept (recommended) or fix.
+3. **Defaults in §3.2** — accept or override.
+4. **Scope locked** to `CBTRN02C` only — yes/no.
+
+Once confirmed, work proceeds through steps 1–11 in §4, one commit per step.

--- a/docs/migration/CBTRN03C-to-java-plan.md
+++ b/docs/migration/CBTRN03C-to-java-plan.md
@@ -1,0 +1,389 @@
+# Migration Plan: `CBTRN03C.cbl` → Java
+
+**Source program:** `app/cbl/CBTRN03C.cbl` — the **transaction detail report** of CardDemo. Produces a paginated, banded, formatted detail report of all transactions whose processing date falls inside an inclusive `[WS-START-DATE, WS-END-DATE]` window read from `DATEPARM`. Subtotals at account-break, page-break (every 20 lines), and one grand total at EOF.
+
+**Driving JCL:** `app/jcl/TRANREPT.jcl` (multi-step: REPRO master → DFSORT to filter and sort → `CBTRN03C`).
+
+**Target location (mandatory):** `app/java/batch_processing_workflow/`
+
+**Goal:** A Java port that produces a **byte-for-byte identical** `TRANREPT` output (RECFM=FB, LRECL=133) on the same input fixtures, verified by an automated test that diffs against a GnuCOBOL-runnable reference build.
+
+This plan is purely a plan. **No code is written until approved.**
+
+---
+
+## 1. Source contract — what `CBTRN03C` does
+
+### 1.1 Inputs
+
+| DD name | COBOL `SELECT` | Org / Access | Record (copybook) | Notes |
+| ------- | -------------- | ------------ | ----------------- | ----- |
+| `TRANFILE` | `TRANSACT-FILE` | SEQUENTIAL | 350 bytes (`CVTRA05Y`) | Daily-filtered, **card-number-sorted** output of the JCL's preceding `SORT` step. Drives the loop. |
+| `CARDXREF` | `XREF-FILE` | INDEXED / RANDOM | 50 bytes (`CVACT03Y`) | Lookup by `TRAN-CARD-NUM` for description fields. |
+| `TRANTYPE` | `TRANTYPE-FILE` | INDEXED / RANDOM | 60 bytes (`CVTRA03Y`) | Lookup by 2-byte `TRAN-TYPE-CD` for type description. |
+| `TRANCATG` | `TRANCATG-FILE` | INDEXED / RANDOM | 60 bytes (`CVTRA04Y`) | Lookup by composite `(TRAN-TYPE-CD, TRAN-CAT-CD)` for category description. |
+| `DATEPARM` | `DATE-PARMS-FILE` | SEQUENTIAL | 80 bytes | Single-record window: `YYYY-MM-DD YYYY-MM-DD` (start, end). |
+
+### 1.2 Outputs
+
+| DD name | COBOL `SELECT` | Org / Access | Record | Notes |
+| ------- | -------------- | ------------ | ------ | ----- |
+| `TRANREPT` | `REPORT-FILE` | SEQUENTIAL | 133 bytes FB | The formatted report. |
+| `SYSOUT` | n/a | text | various | Banners; informational status decode. |
+
+### 1.3 Algorithm (paragraph map)
+
+```
+PROCEDURE DIVISION:
+    DISPLAY 'START OF EXECUTION OF PROGRAM CBTRN03C'
+    OPEN all 6 files (paragraphs 0000–0500). ABEND on non-'00'.
+
+    PERFORM 0550-DATEPARM-READ              → load WS-START-DATE, WS-END-DATE
+
+    LOOP UNTIL END-OF-FILE = 'Y':
+        PERFORM 1000-TRANFILE-GET-NEXT
+        IF END-OF-FILE = 'N':
+            IF TRAN-PROC-TS(1:10) NOT IN [WS-START-DATE, WS-END-DATE]: NEXT SENTENCE
+            IF TRAN-CARD-NUM has changed since last record:
+                PERFORM 1120-WRITE-ACCOUNT-TOTALS  (skip on first record)
+                PERFORM 1110-LOOKUP-XREF           (re-fetch card-account info)
+                Reset WS-ACCOUNT-TOTAL = 0
+            PERFORM 1120-LOOKUP-TRANTYPE   (random read by TRAN-TYPE-CD)
+            PERFORM 1130-LOOKUP-TRANCATG   (random read by composite key)
+            PERFORM 1100-WRITE-TRANSACTION-REPORT:
+                IF FUNCTION MOD(WS-LINE-COUNTER, WS-PAGE-SIZE) = 0:
+                    PERFORM 1110-WRITE-PAGE-TOTALS  (skip on first page)
+                    Print page header
+                PERFORM 1120-WRITE-DETAIL          (single 133-byte data line)
+                ADD WS-TRAN-AMT TO WS-ACCOUNT-TOTAL, WS-PAGE-TOTAL, WS-GRAND-TOTAL
+                ADD 1 TO WS-LINE-COUNTER
+
+    PERFORM 1120-WRITE-ACCOUNT-TOTALS              (final account)
+    PERFORM 1110-WRITE-PAGE-TOTALS                 (final page)
+    PERFORM 1130-WRITE-GRAND-TOTAL                 (grand total)
+    CLOSE all 6 files (9000–9500). ABEND on non-'00'.
+    DISPLAY 'END OF EXECUTION OF PROGRAM CBTRN03C'
+    GOBACK
+```
+
+(Paragraph numbers above are illustrative — verify against the source during step 1 of §4.)
+
+### 1.4 Report layout — 133 bytes per line
+
+The report layouts live in `CVTRA07Y` (`REPORT-NAME-HEADER`,
+`TRANSACTION-DETAIL-REPORT`, `TRANSACTION-HEADER-1`,
+`TRANSACTION-HEADER-2`, `REPORT-PAGE-TOTALS`,
+`REPORT-ACCOUNT-TOTALS`, `REPORT-GRAND-TOTALS`). Each is exactly 133
+bytes (RECFM=FB, LRECL=133, the standard mainframe report width).
+
+Each line type is a fixed-position record with:
+
+- Text labels (e.g. `'PAGE TOTAL:'`, `'ACCOUNT'`).
+- Edited numeric fields with PIC clauses like `PIC -ZZZ,ZZZ,ZZZ.ZZ`
+  for amounts (zero-suppressed, comma-grouped, signed).
+- Spaces (`PIC X(N)`) for separators and indents.
+- A trailing band of `'-'` characters in the header lines.
+
+Step 1 of §4 dumps every layout from `CVTRA07Y` and tabulates each
+line's layout (offsets, lengths, PIC clauses) — this becomes the
+contract for the Java `Report*Line` classes.
+
+### 1.5 Pagination
+
+Page size: `WS-PAGE-SIZE = 20` (defined in working storage). Pagination
+trigger: `IF FUNCTION MOD(WS-LINE-COUNTER, WS-PAGE-SIZE) = 0`. **The
+counter is incremented after each detail line is written.**
+
+Order of operations on a page break:
+1. Write page-total line for the prior page.
+2. Write page header (3 lines: report name + 2-line column header).
+3. Write the detail line for the current transaction.
+
+### 1.6 Date filter
+
+```cobol
+IF (TRAN-PROC-TS (1:10) >= WS-START-DATE
+AND TRAN-PROC-TS (1:10) <= WS-END-DATE)
+    [process]
+ELSE
+    NEXT SENTENCE
+```
+
+The first 10 bytes of `TRAN-PROC-TS` (`YYYY-MM-DD`) are string-compared against the window. Same lexical-vs-chronological argument as `CBTRN02C` §5.5 — string comparison is fine because the format is `YYYY-MM-DD`.
+
+### 1.7 Edited PIC clauses to replicate
+
+| PIC | Width | Java equivalent |
+| --- | ----- | --------------- |
+| `-ZZZ,ZZZ,ZZZ.ZZ` | 16 (1 sign + 11 digits/seps + period + 2 cents = 15? — verify in source) | `DecimalFormat(" #,##0.00;-#,##0.00")` plus right-justify-pad to 16 |
+| `+ZZZ,ZZZ,ZZZ.ZZ` | 16 | `DecimalFormat("+#,##0.00;-#,##0.00")` |
+| `ZZ,ZZZ,ZZZ` (record count, e.g.) | 11 | `DecimalFormat("#,##0")` |
+
+Zero-suppressed (`Z`) fields print spaces for leading zeros. Sign
+positions print space (or `+`/`-`) depending on the leading character.
+Java `DecimalFormat` patterns approximate this but need careful
+right-padding/truncation to match the exact COBOL byte layout.
+
+This is the **central new primitive** introduced by this plan:
+`EditedNumericFormat` in the shared `io` package.
+
+---
+
+## 2. Equivalence requirements (acceptance criteria)
+
+1. **`TRANREPT`** matches byte-for-byte. All 133-byte records,
+   including pagination and totals.
+
+**Acceptance test:** `Files.mismatch(expected, actual) == -1L`.
+
+**Sources of divergence to neutralize:**
+
+- **Report header date** — if the program prints "Report run date:
+  YYYY-MM-DD" anywhere, that line uses `FUNCTION CURRENT-DATE`. Inject
+  via `Db2Timestamp.useFixedClock(...)` (reuse from `interest/util`).
+  Audit the source during step 1 of §4 and add the injection point to
+  the COBOL oracle if needed.
+
+---
+
+## 3. Target architecture
+
+### 3.1 Layout
+
+```
+app/java/batch_processing_workflow/
+└── src/
+    ├── main/java/com/carddemo/batch/
+    │   ├── trnrept/                                   ← new subpackage for CBTRN03C
+    │   │   ├── TransactionDetailReport.java           main(); mirrors PROCEDURE DIVISION
+    │   │   ├── domain/
+    │   │   │   ├── TranTypeRecord.java                wraps CVTRA03Y (60 bytes)
+    │   │   │   └── TranCatRecord.java                 wraps CVTRA04Y (60 bytes)
+    │   │   ├── io/
+    │   │   │   └── ReportWriter.java                  appends 133-byte lines to TRANREPT.dat
+    │   │   ├── format/
+    │   │   │   ├── EditedNumericFormat.java           NEW — emulates COBOL PIC -Z,...,Z.ZZ
+    │   │   │   ├── DetailLineBuilder.java             builds one TRANSACTION-DETAIL-REPORT line
+    │   │   │   ├── HeaderLineBuilder.java             builds the 3-line page header
+    │   │   │   ├── PageTotalLineBuilder.java          builds REPORT-PAGE-TOTALS
+    │   │   │   ├── AccountTotalLineBuilder.java       builds REPORT-ACCOUNT-TOTALS
+    │   │   │   └── GrandTotalLineBuilder.java         builds REPORT-GRAND-TOTALS
+    │   │   └── DateParmsReader.java                   parses 80-byte DATEPARM record
+    │   ├── interest/                                  ← UNCHANGED
+    │   └── …                                          ← other packages unchanged
+    └── test/java/com/carddemo/batch/trnrept/
+        ├── EditedNumericFormatTest.java               broad-coverage parameterised
+        ├── DetailLineBuilderTest.java                 byte-exact for known transaction
+        ├── HeaderLineBuilderTest.java                 byte-exact
+        ├── PaginationLogicTest.java                   page break at line 21, not 20
+        ├── DateFilterTest.java                        boundary cases
+        ├── AccountBreakLogicTest.java                 sub-total sequencing
+        ├── TransactionDetailReportTest.java           end-to-end smoke
+        └── TransactionDetailReportGoldenFileEquivalenceIT.java
+```
+
+### 3.2 Decisions
+
+| Decision | Default | Why |
+| -------- | ------- | --- |
+| Java version | **Java 17** | Same module |
+| Report record format | **133-byte fixed; no terminator on disk; LF on `LINE SEQUENTIAL OUTPUT` from oracle** | Matches mainframe FB; the oracle adds an LF (one byte) that becomes part of the byte-equivalence check. **Both sides emit identical bytes including LF.** |
+| Edited numeric formatting | **New `EditedNumericFormat` class** in shared `io` | First port that needs PIC-edit emulation; lifts to shared as soon as a second caller emerges |
+| Lookup stores | **`IndexedFileStore<K, V>`** for `XREF`, `TRANTYPE`, `TRANCATG` (all read-only) | Promoted in `CBTRN01C` plan |
+| Pagination | **Counter approach**: increment line counter, check `% pageSize == 0` after each detail line, fire page break before the *next* detail | Matches the `FUNCTION MOD(WS-LINE-COUNTER, WS-PAGE-SIZE) = 0` pattern |
+| Account-break | **Compare current `TRAN-CARD-NUM` to previous; on change emit account-total then re-fetch xref** | First card → no account-total emitted (special-cased on first record) |
+| Date filter | **String compare on `YYYY-MM-DD`** | No `LocalDate` parsing |
+| Decimal accumulation | **`BigDecimal` with scale 2** | Standard |
+
+### 3.3 Why a sequential-file GnuCOBOL port
+
+`CBTRN03P.cbl`:
+- `XREF-FILE`, `TRANTYPE-FILE`, `TRANCATG-FILE` change from `INDEXED RANDOM` to in-memory tables loaded via `LINE SEQUENTIAL INPUT` at OPEN; `READ … KEY … INVALID KEY` becomes `SEARCH ALL` on the in-memory table with `WHEN OTHER` → `INVALID KEY` body.
+- `TRANSACT-FILE` (input) was already sequential — `LINE SEQUENTIAL INPUT`. **Critically, the JCL pre-sorts this file** before invoking the program; the portable oracle assumes the input fixture is already sorted on `TRAN-CARD-NUM`.
+- `REPORT-FILE` was already sequential — `LINE SEQUENTIAL OUTPUT`. The 133-byte fixed-record assumption requires `COB_LS_FIXED=Y`.
+- `DATE-PARMS-FILE` was already sequential — `LINE SEQUENTIAL INPUT`.
+- All business-logic paragraphs and `CVTRA07Y` layouts copied verbatim.
+
+---
+
+## 4. Step-by-step migration steps
+
+| # | Step | Acceptance |
+| - | ---- | ---------- |
+| 1 | Tabulate `CVTRA07Y` layouts (offsets, lengths, PIC clauses) into a Markdown table inside this plan. Verify each line type is exactly 133 bytes. | Table complete; total 133 bytes per type |
+| 2 | Implement `EditedNumericFormat` for `-ZZZ,ZZZ,ZZZ.ZZ`, `+ZZZ,ZZZ,ZZZ.ZZ`, and `ZZ,ZZZ,ZZZ` patterns. Right-justified, zero-suppressed, sign-padded. | Parameterised test covers: 0, 1, 1234567.89, -1234567.89, max value, edge cases (sign character placement) |
+| 3 | Define `TranTypeRecord` (60 bytes) and `TranCatRecord` (60 bytes) with their accessors. | Round-trip tests pass |
+| 4 | Implement the 6 line-builder classes (`DetailLineBuilder`, `HeaderLineBuilder`, `PageTotalLineBuilder`, `AccountTotalLineBuilder`, `GrandTotalLineBuilder`, plus the report-name banner). Each produces exactly 133 bytes. | Byte-exact tests for known inputs |
+| 5 | Implement `DateParmsReader` — parses the 80-byte DATEPARM record into `(LocalDate startInclusive, LocalDate endInclusive)` (or as `String` if format is fixed). | Unit test |
+| 6 | Implement `TransactionDetailReport.main()` — wires the readers, the lookup stores, the line builders, and the writer. | Runs end-to-end on fixtures |
+| 7 | Write `cobol-reference/CBTRN03P.cbl` (sequential-only oracle as in §3.3) plus the build/run/regen scripts. The fixture for `TRANSACT-FILE` is the sorted output of `tools/sort-trans.sh` (mimics the JCL `SORT` step). | `bash regen-golden.sh` produces `fixtures/expected/tranrept.dat` |
+| 8 | Write the unit tests in §6.1 plus pagination and account-break logic tests. | All pass |
+| 9 | Write `TransactionDetailReportGoldenFileEquivalenceIT`. | Passes |
+| 10 | Update `docs/cobol/batch-programs.md` `CBTRN03C` section pointer. | Pointer added |
+
+**Estimated effort:** ~2–3 engineering days. The bulk of the surprise is in step 2 (`EditedNumericFormat` correctness — COBOL edit pictures have 30+ corner cases) and step 4 (every line builder has to match exact byte offsets from `CVTRA07Y`).
+
+---
+
+## 5. Logic equivalency safeguards
+
+### 5.1 `EditedNumericFormat` corner cases
+
+The hardest primitive in this plan. Test cases that must pass:
+
+| Input value | Pattern | Expected output (visible chars; trailing pad if any) |
+| ----------- | ------- | ----------------------------------------------------- |
+| `0.00` | `-ZZZ,ZZZ,ZZZ.ZZ` | `(15 spaces)` (full zero-suppression) |
+| `1.00` | `-ZZZ,ZZZ,ZZZ.ZZ` | `             1.00` (padded) |
+| `-1.00` | `-ZZZ,ZZZ,ZZZ.ZZ` | `            -1.00` |
+| `1234567.89` | `-ZZZ,ZZZ,ZZZ.ZZ` | `     1,234,567.89` |
+| `-1234567.89` | `-ZZZ,ZZZ,ZZZ.ZZ` | `    -1,234,567.89` |
+| `9999999999.99` | `-ZZZ,ZZZ,ZZZ.ZZ` | overflow → `*` fill in COBOL? **Verify against source** |
+
+The **exact width** must be verified — `-ZZZ,ZZZ,ZZZ.ZZ` is 1 (sign) + 11 (digits/commas) + 3 (period + 2 cents) = 15? Or 16? The literal byte count of the COBOL `PIC` clause string is the source of truth. Verify in step 1.
+
+### 5.2 First-account suppression
+
+On the very first transaction, `TRAN-CARD-NUM` has no previous value to compare against, so the account-total branch fires spuriously. The COBOL source guards with a `WS-FIRST-TIME` flag (or a similar idiom; verify in source). Java must replicate.
+
+### 5.3 EOF flush of last account-total, page-total, grand-total
+
+When the loop ends, the program emits one final account-total, one final page-total, then the grand total. The Java port must do all three after the loop exits.
+
+### 5.4 Pagination edge cases
+
+- Exactly 20 detail lines on the first page → page-total fires after line 20, then header for page 2, then no more details → page 2 emits *only* the header? **Verify in source** — the program may suppress empty-page headers.
+- 0 detail lines (no transactions in date window) → no headers, no totals (?), only banners?
+
+### 5.5 Account-total reset
+
+`WS-ACCOUNT-TOTAL` resets to zero on account break. `WS-PAGE-TOTAL` resets to zero on page break. `WS-GRAND-TOTAL` never resets. Java needs three separate `BigDecimal` accumulators.
+
+### 5.6 LRECL=133 enforcement
+
+Every output line is exactly 133 bytes. If a builder emits 132 or 134, the IT fails. Each `*LineBuilder` test asserts `output.length == 133`.
+
+### 5.7 GnuCOBOL `LINE SEQUENTIAL OUTPUT` adds LF
+
+The portable oracle's report writer appends `\n` (1 byte) to each 133-byte line. Total per record on disk: 134 bytes. `COB_LS_FIXED=Y` does *not* suppress the LF on output. The Java port writes 133 bytes + `\n`. Document this in `HOW-TO-TEST.md` so it's not a surprise.
+
+### 5.8 Date-window inclusivity
+
+The `(1:10) >= WS-START-DATE AND (1:10) <= WS-END-DATE` form is **inclusive** on both ends. Java: `procDate.compareTo(startDate) >= 0 && procDate.compareTo(endDate) <= 0`.
+
+### 5.9 Qualified-name lookup
+
+```cobol
+MOVE TRAN-TYPE-CD OF TRAN-RECORD TO FD-TRAN-TYPE-CD OF FD-TRAN-CAT-KEY
+```
+
+This `OF`-qualified `MOVE` disambiguates a field name that exists in two records. Java needs no special handling — the source field is on the input record class, the destination is on the lookup-key class. Plain getter/setter call.
+
+---
+
+## 6. Test strategy
+
+### 6.1 Unit tests
+
+| Test class | Concern |
+| ---------- | ------- |
+| `EditedNumericFormatTest` | Parameterised; the 30+ corner cases above |
+| `DetailLineBuilderTest` | Byte-exact for one canonical detail line |
+| `HeaderLineBuilderTest` | Byte-exact for the 3-line header |
+| `PageTotalLineBuilderTest` | Byte-exact for known total |
+| `AccountTotalLineBuilderTest` | Byte-exact |
+| `GrandTotalLineBuilderTest` | Byte-exact |
+| `PaginationLogicTest` | After 20 detail lines, the 21st write triggers page break |
+| `DateFilterTest` | Boundary: date == start, date == end, date one day before/after |
+| `AccountBreakLogicTest` | First record never fires account-total; subsequent card change does |
+
+### 6.2 Smoke test
+
+`TransactionDetailReportTest` against a 5-record synthetic fixture (3 cards × dates spanning the window): asserts the line count and the order of emit operations (detail/account-total/page-header/grand-total).
+
+### 6.3 Golden-file integration test
+
+```
+1. cd cobol-reference && bash tools/regen-golden.sh
+   → tools/sort-trans.sh fixtures/input/transact.dat → fixtures/input/transact.sorted.dat
+   → cobc -x -free -fsign=EBCDIC CBTRN03P.cbl
+   → COB_LS_FIXED=Y ./CBTRN03P
+   → cp tranrept.dat → fixtures/expected/
+
+2. mvn verify
+   → TransactionDetailReportGoldenFileEquivalenceIT
+       Files.mismatch(expected/tranrept.dat, temp/tranrept.dat) == -1L
+```
+
+### 6.4 Synthetic edge-case fixtures
+
+| Fixture | Purpose |
+| ------- | ------- |
+| `single-account-single-page/` | 5 transactions, all same card, fits on one page → 1 page header, 5 details, 1 account-total, 1 page-total, 1 grand-total |
+| `single-account-multi-page/` | 25 transactions, all same card → 2 page headers, 25 details, 1 account-total at end, 2 page-totals, 1 grand-total |
+| `multi-account-single-page/` | 5 transactions across 3 cards → 1 page header, 5 details, 3 account-totals, 1 page-total, 1 grand-total |
+| `outside-window/` | All transactions outside `[start, end]` → 0 details, no headers/totals (just banners) |
+| `boundary-window/` | One transaction with `date == start`, one with `date == end` |
+| `all-zero-amounts/` | All amounts are 0.00 → `EditedNumericFormat` emits all-spaces fields |
+
+---
+
+## 7. Documents to be produced during implementation
+
+1. Append a "CBTRN03C — Transaction Detail Report" section to
+   `app/java/batch_processing_workflow/README.md`.
+2. Append a CBTRN03C section to `HOW-TO-TEST.md` with the
+   `tools/sort-trans.sh` step.
+3. Add `docs/migration/CBTRN03C-java-architecture.md`.
+4. Update `docs/cobol/batch-programs.md` `CBTRN03C` section pointer.
+5. Document the new `EditedNumericFormat` API in the shared `io`
+   package's javadoc.
+6. The full `CVTRA07Y` layout table (from step 1 of §4) lands in this
+   document as an appendix.
+
+---
+
+## 8. Risks and open decisions
+
+### 8.1 Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `EditedNumericFormat` byte width mismatches by 1 → entire report shifted | Step 4 byte-exact builder tests catch on first run |
+| Pagination off-by-one (page break before line 20 vs after) | `PaginationLogicTest` exercises both cases |
+| `LINE SEQUENTIAL OUTPUT` adds an LF that the Java port omits → IT fails on byte 134 | Java port writes `\n` after each 133-byte record; documented in `HOW-TO-TEST.md` |
+| Sort-step approximation (`tools/sort-trans.sh`) doesn't replicate DFSORT exactly | `sort -t … -k …` on the relevant byte range; document the exact sort key in `tools/sort-trans.sh` |
+| Empty page header on a fixture that ends exactly at line 20 | Verify in source whether the program suppresses empty-page headers; mirror in Java |
+
+### 8.2 Open decisions to confirm
+
+1. **`EditedNumericFormat` placement** — defaulting to shared
+   `com.carddemo.batch.io.format`. Accept?
+2. **`tools/sort-trans.sh`** as a replacement for the JCL DFSORT step
+   — accept the approximation or specify the exact sort algorithm.
+3. **Defaults in §3.2** — accept or override.
+4. **Scope locked** to `CBTRN03C` only — yes/no.
+
+---
+
+## 9. Out of scope for this migration
+
+- The DFSORT JCL step that pre-filters/sorts `TRANFILE`. The portable
+  oracle and the IT use a `tools/sort-trans.sh` shell script instead.
+- Multiple report formats. Only the `TRANREPT` 133-byte FB report is
+  produced.
+- Localisation of dates / numbers. The COBOL source is en-US-only;
+  the port matches.
+
+---
+
+## 10. Approval gate
+
+Confirm before implementation:
+
+1. **`EditedNumericFormat`** in shared `io.format` — accept.
+2. **`tools/sort-trans.sh`** as the DFSORT replacement — accept.
+3. **Defaults in §3.2** — accept or override.
+4. **Scope locked** to `CBTRN03C` only — yes/no.
+
+Once confirmed, work proceeds through steps 1–10 in §4.

--- a/docs/migration/CSUTLDTC-to-java-plan.md
+++ b/docs/migration/CSUTLDTC-to-java-plan.md
@@ -1,0 +1,331 @@
+# Migration Plan: `CSUTLDTC.cbl` → Java
+
+**Source program:** `app/cbl/CSUTLDTC.cbl` — the **date-validation utility** of CardDemo. A subroutine wrapping the LE callable service `CEEDAYS`. Returns a 15-character English message describing the validation result (`Date is valid`, `Invalid month`, etc.) plus an LE severity in `RETURN-CODE`. Called from `CSUTLDPY` (a copybook glue) and from online programs `CORPT00C` / `COTRN02C`.
+
+**Driving JCL:** None — invoked as a dynamic-call subprogram via `CALL 'CSUTLDTC' USING LS-DATE, LS-DATE-FORMAT, LS-RESULT`.
+
+**Target location (mandatory):** `app/java/batch_processing_workflow/`
+
+**Goal:** A Java port that produces a **byte-for-byte identical** 80-byte `WS-MESSAGE` and the same severity code as the COBOL source on every supported (date, format) pair, verified by a parameterised test against a GnuCOBOL-runnable reference build.
+
+This plan is purely a plan. **No code is written until approved.**
+
+---
+
+## 1. Source contract — what `CSUTLDTC` does
+
+### 1.1 Inputs (LINKAGE SECTION)
+
+| Linkage name | PIC | Notes |
+| ------------ | --- | ----- |
+| `LS-DATE` | `PIC X(10)` | Date string under test, e.g. `"2025-04-29"` or `"04/29/2025"` |
+| `LS-DATE-FORMAT` | `PIC X(10)` | LE picture string, e.g. `"YYYY-MM-DD"`, `"MM/DD/YYYY"` |
+| `LS-RESULT` | `PIC X(80)` | Output buffer for the formatted message |
+
+### 1.2 Outputs
+
+| Output | Format | Notes |
+| ------ | ------ | ----- |
+| `LS-RESULT` (`PIC X(80)`) | `WS-MESSAGE` formatted layout (see §1.4) | Filled by the routine before `EXIT PROGRAM` |
+| `RETURN-CODE` | LE severity (0/1/2/3) | Set from `WS-SEVERITY-N` after `CEEDAYS` returns |
+
+### 1.3 Algorithm
+
+```
+PROCEDURE DIVISION USING LS-DATE, LS-DATE-FORMAT, LS-RESULT:
+    INITIALIZE WS-MESSAGE; MOVE SPACES TO WS-DATE
+    PERFORM A000-MAIN THRU A000-MAIN-EXIT:
+        Build VString-shaped WS-DATE-TO-TEST from LS-DATE
+        Build VString-shaped WS-DATE-FORMAT from LS-DATE-FORMAT
+        MOVE 0 TO OUTPUT-LILLIAN
+        CALL "CEEDAYS" USING WS-DATE-TO-TEST, WS-DATE-FORMAT,
+                              OUTPUT-LILLIAN, FEEDBACK-CODE
+        MOVE WS-DATE-TO-TEST            TO WS-DATE
+        MOVE SEVERITY OF FEEDBACK-CODE  TO WS-SEVERITY-N
+        MOVE MSG-NO OF FEEDBACK-CODE    TO WS-MSG-NO-N
+        EVALUATE TRUE
+            WHEN FC-INVALID-DATE        MOVE 'Date is valid'   TO WS-RESULT
+            WHEN FC-INSUFFICIENT-DATA   MOVE 'Insufficient'    TO WS-RESULT
+            WHEN FC-BAD-DATE-VALUE      MOVE 'Datevalue error' TO WS-RESULT
+            WHEN FC-INVALID-ERA         MOVE 'Invalid Era    ' TO WS-RESULT
+            WHEN FC-UNSUPP-RANGE        MOVE 'Unsupp. Range  ' TO WS-RESULT
+            WHEN FC-INVALID-MONTH       MOVE 'Invalid month  ' TO WS-RESULT
+            WHEN FC-BAD-PIC-STRING      MOVE 'Bad Pic String ' TO WS-RESULT
+            WHEN FC-NON-NUMERIC-DATA    MOVE 'Nonnumeric data' TO WS-RESULT
+            WHEN FC-YEAR-IN-ERA-ZERO    MOVE 'YearInEra is 0 ' TO WS-RESULT
+            WHEN OTHER                  MOVE 'Date is invalid' TO WS-RESULT
+        END-EVALUATE
+    MOVE WS-MESSAGE TO LS-RESULT
+    MOVE WS-SEVERITY-N TO RETURN-CODE
+    EXIT PROGRAM
+```
+
+### 1.4 `WS-MESSAGE` layout — 80 bytes total
+
+| Offset | Len | Content |
+| ------ | --- | ------- |
+| 0 | 4 | `WS-SEVERITY` — `'%04d' % severity` |
+| 4 | 11 | Literal `'Mesg Code: '` (11 chars) — note copybook says `PIC X(11) VALUE 'Mesg Code:'` so offset depends on whether the colon-space is part of the literal or padding |
+| 15 | 4 | `WS-MSG-NO` — `'%04d' % msg-no` |
+| 19 | 1 | space |
+| 20 | 15 | `WS-RESULT` (the 15-char English message above) |
+| 35 | 1 | space |
+| 36 | 9 | Literal `'TstDate: '` (note 8-char literal + 1 space, but the copybook declares it `PIC X(09) VALUE 'TstDate:'` so total is 9 bytes including trailing pad) |
+| 45 | 10 | `WS-DATE` — copy of `LS-DATE` |
+| 55 | 1 | space |
+| 56 | 10 | Literal `'Mask used:'` |
+| 66 | 10 | `WS-DATE-FMT` — copy of `LS-DATE-FORMAT` |
+| 76 | 1 | space |
+| 77 | 3 | spaces (final FILLER) |
+
+**Total: 80 bytes** — matches `LS-RESULT PIC X(80)`. Exact byte offsets must be re-verified against `app/cbl/CSUTLDTC.cbl` line 42–58 during implementation; the COBOL `02 FILLER PIC X(11) VALUE 'Mesg Code:'` declares an 11-byte field whose `VALUE` is a 10-byte string, so byte 14 is space-padded by COBOL's value-shorter-than-PIC rule. The Java port must replicate this padding exactly.
+
+### 1.5 LE feedback-token mapping (CEEDAYS)
+
+| 88-level | 8-byte hex VALUE | Severity (typical) | English message (15 chars exact) |
+| -------- | ---------------- | ------------------ | --------------------------------- |
+| `FC-INVALID-DATE` | `X'0000000000000000'` | 0 | `Date is valid` (13 chars + 2 trailing spaces) |
+| `FC-INSUFFICIENT-DATA` | `X'000309CB59C3C5C5'` | 3 | `Insufficient` (12 chars + 3 trailing spaces) |
+| `FC-BAD-DATE-VALUE` | `X'000309CC59C3C5C5'` | 3 | `Datevalue error` (15 chars exact) |
+| `FC-INVALID-ERA` | `X'000309CD59C3C5C5'` | 3 | `Invalid Era    ` (12 chars + 3 trailing spaces, hard-coded by `MOVE 'Invalid Era    '`) |
+| `FC-UNSUPP-RANGE` | `X'000309D159C3C5C5'` | 3 | `Unsupp. Range  ` (13 + 2 trailing) |
+| `FC-INVALID-MONTH` | `X'000309D559C3C5C5'` | 3 | `Invalid month  ` (13 + 2) |
+| `FC-BAD-PIC-STRING` | `X'000309D659C3C5C5'` | 3 | `Bad Pic String ` (14 + 1) |
+| `FC-NON-NUMERIC-DATA` | `X'000309D859C3C5C5'` | 3 | `Nonnumeric data` (15 exact) |
+| `FC-YEAR-IN-ERA-ZERO` | `X'000309D959C3C5C5'` | 3 | `YearInEra is 0 ` (14 + 1) |
+| (OTHER / unmatched) | (any) | 3 | `Date is invalid` (15 exact) |
+
+The `MOVE` literals in the source preserve trailing spaces inside the
+quotes, so a `'Invalid Era    '` literal is 12 visible chars + 4
+trailing spaces = 16 chars *but* the destination `WS-RESULT` is
+`PIC X(15)`, so the last char is dropped on the move. Java must do the
+same: format each constant to exactly 15 bytes, padded with ASCII
+spaces on the right, truncated on the left if too long.
+
+---
+
+## 2. Equivalence requirements (acceptance criteria)
+
+For every (date, format) pair in the test matrix:
+
+1. **`LS-RESULT`** — the 80 bytes returned must match byte-for-byte
+   between the GnuCOBOL run (with a stub `CEEDAYS`) and the Java port.
+2. **`RETURN-CODE`** — the integer severity returned must match.
+
+**Acceptance test:** `mvn test` runs a parameterised JUnit test that:
+1. Invokes `CsutldtcUtil.validate(date, format)` and captures
+   `(messageBytes, severity)`.
+2. Asserts both equal the expected values from the matrix.
+
+A separate IT runs the GnuCOBOL oracle (with a stubbed `CEEDAYS`)
+over the same matrix and compares its outputs to the Java outputs.
+
+---
+
+## 3. Target architecture
+
+### 3.1 Layout
+
+```
+app/java/batch_processing_workflow/
+└── src/
+    ├── main/java/com/carddemo/batch/
+    │   └── dateutil/                             ← new subpackage for CSUTLDTC
+    │       ├── CsutldtcUtil.java                 public-static validate(date, format) → (bytes, severity)
+    │       ├── DateValidationResult.java         record { byte[] message80; int severity; }
+    │       ├── LeFeedbackCode.java               enum INVALID_DATE, INSUFFICIENT_DATA, … with hex token + 15-byte message + severity
+    │       └── DatePictureParser.java            translates LE picture strings to Java DateTimeFormatter
+    └── test/java/com/carddemo/batch/dateutil/
+        ├── CsutldtcUtilTest.java                 parameterised; covers every LE feedback branch
+        ├── DatePictureParserTest.java
+        └── CsutldtcGoldenEquivalenceIT.java      diff against GnuCOBOL oracle outputs
+```
+
+### 3.2 Decisions
+
+| Decision | Default | Why |
+| -------- | ------- | --- |
+| Replace `CEEDAYS` with | **`LocalDate.parse(date, formatter)`** wrapped in try/catch | The Lillian-day output is unused; only the validity result matters |
+| Picture-string translation | **`DatePictureParser`** mapping `YYYY-MM-DD` → `yyyy-MM-dd`, `MM/DD/YYYY` → `MM/dd/yyyy`, etc. | LE picture strings differ slightly from `DateTimeFormatter` patterns |
+| Severity mapping | **0 for valid, 3 for any parse failure** | Matches the dominant LE convention; hand-mapped per branch (no LE library dependency) |
+| Output encoding | **ISO-8859-1 byte-identity** | Same as every other batch port |
+| GnuCOBOL oracle | **Stub `CEEDAYS`** | The real `CEEDAYS` is mainframe-only; the oracle uses a `cobc -x` build with a hand-written `CEEDAYS.c` stub that matches LE feedback codes for the test matrix |
+
+### 3.3 New shared utility (none needed)
+
+This plan introduces **no** new shared utilities. It uses
+`FixedWidthFormat.writeText` / `padToLength` from the shared `io`
+package for the 80-byte message construction, and
+`java.time.LocalDate` for the parse.
+
+### 3.4 Why a stubbed-CEEDAYS GnuCOBOL oracle
+
+`CEEDAYS` is part of the IBM Language Environment runtime and is not
+available in GnuCOBOL. The portable oracle (`CSUTLDTP.cbl`) keeps
+`CSUTLDTC.cbl` byte-identical except for an extra `CALL 'CEEDAYS'`
+linkage to a small `cobol-reference/CEEDAYS-stub.c` file that returns
+hard-coded feedback codes for the test matrix:
+
+```c
+// CEEDAYS-stub.c — for the CSUTLDTP oracle only
+void CEEDAYS(char *date_vstring, char *fmt_vstring,
+             int *out_lillian, char *fb_code) {
+    // Match a small set of (date, format) inputs to the LE feedback
+    // tokens listed in CSUTLDTC.cbl §1.5.
+}
+```
+
+This is a thin shim. The oracle is not for testing every
+`CEEDAYS`-supported format — it's for proving Java≡COBOL on the
+specific feedback-handling branches.
+
+---
+
+## 4. Step-by-step migration steps
+
+| # | Step | Acceptance |
+| - | ---- | ---------- |
+| 1 | Define `LeFeedbackCode` enum with one constant per `FC-*` 88-level (§1.5). Each constant carries the 8-byte hex token, the 15-byte ASCII message, and the severity. | Unit test asserts each constant's message is exactly 15 bytes and severity matches the matrix |
+| 2 | Implement `DatePictureParser.translate(String pictureString)` returning a `DateTimeFormatter`. Cover at least: `YYYY-MM-DD`, `MM/DD/YYYY`, `DD/MM/YYYY`, `YYYYMMDD`. | Unit test maps each known input format to a parseable `DateTimeFormatter` |
+| 3 | Implement `CsutldtcUtil.validate(date, format) → DateValidationResult` that:<br>1. parses `format` via `DatePictureParser`,<br>2. tries `LocalDate.parse(date, formatter)`,<br>3. on success returns `INVALID_DATE` (severity 0, message `"Date is valid"`),<br>4. on `DateTimeParseException` maps to one of the LE constants (best-effort: `month` failures → `INVALID_MONTH`, etc.). | Parameterised test passes for the matrix |
+| 4 | Implement the 80-byte `WS-MESSAGE` builder using `FixedWidthFormat.writeText` for each literal/field. | Test for a known-valid date asserts byte 0–3 = `"0000"`, bytes 20–34 = `"Date is valid  "`, etc. |
+| 5 | Write `cobol-reference/CSUTLDTP.cbl` (verbatim copy of `CSUTLDTC.cbl`; no source change) plus `CEEDAYS-stub.c` and a `tools/build-cdate.sh`. | Compiles; runs against the test matrix |
+| 6 | Write `CsutldtcGoldenEquivalenceIT` that calls both the GnuCOBOL binary (via `Runtime.exec`) and the Java port for each test case in the matrix and asserts byte-equivalence on `LS-RESULT` + severity. | Passes |
+| 7 | Update `docs/cobol/batch-programs.md` `CSUTLDTC` section pointer. | Pointer added |
+
+**Estimated effort:** ~1–1.5 engineering days. Most of the work is in the picture-string translator (step 2) and the byte-exact message builder (step 4). The CEEDAYS stub is small.
+
+---
+
+## 5. Logic equivalency safeguards
+
+### 5.1 15-byte fixed-width result strings
+
+Every `WS-RESULT` literal is exactly 15 bytes. COBOL truncates a 16-byte literal moved into a 15-byte field on the right (left-justified). Java must format every constant to exactly 15 bytes and never emit a 14- or 16-byte string. A unit test asserts each constant byte length.
+
+### 5.2 Severity mapping
+
+The COBOL source maps LE feedback tokens to severity values inside `CEEDAYS` itself; the program reads them from `SEVERITY OF FEEDBACK-CODE`. The Java port doesn't have access to LE — it must hard-code severity per branch. The matrix in §1.5 is the source of truth.
+
+### 5.3 Trailing-FILLER preservation in `LS-RESULT`
+
+Bytes 76–79 are spaces from the `02 FILLER PIC X(03) VALUE SPACES` plus a trailing space. The `INITIALIZE WS-MESSAGE` at the start of A000-MAIN guarantees this, regardless of the previous call. Java must `Arrays.fill(buf, (byte) ' ')` first, then overwrite specific offsets.
+
+### 5.4 `WS-DATE` and `WS-DATE-FMT` echo the inputs verbatim
+
+`MOVE LS-DATE TO WS-DATE` (line 122 in source) copies the input date string into the message buffer. If the input is not 10 chars (e.g. a caller passes `"2025-4-29 "`), COBOL right-pads with spaces. Java must do the same — call `FixedWidthFormat.writeText(buf, offset, 10, input)`.
+
+### 5.5 Severity-string formatting
+
+`WS-SEVERITY` is `PIC X(04)` redefined as `PIC 9(04)`. Setting it via `MOVE WS-SEVERITY-N TO ...` zero-pads to 4 digits. Java must use `String.format("%04d", severity)`.
+
+### 5.6 ISO-8859-1 byte identity
+
+All `MOVE`s in COBOL are byte copies. Java's String operations risk introducing UTF-8 multi-byte sequences if a customer passed in a non-ASCII date format string. Use `byte[]` throughout the message builder; do not go through `String` for the buffer construction.
+
+---
+
+## 6. Test strategy
+
+### 6.1 Unit tests — the test matrix
+
+| Date | Format | Expected severity | Expected message (15 bytes) |
+| ---- | ------ | ------------------ | ---------------------------- |
+| `2025-04-29` | `YYYY-MM-DD` | 0 | `Date is valid ` |
+| `2025-13-01` | `YYYY-MM-DD` | 3 | `Invalid month  ` |
+| `2025-04-32` | `YYYY-MM-DD` | 3 | `Datevalue error` |
+| `04/29/2025` | `YYYY-MM-DD` | 3 | `Bad Pic String ` (or `Date is invalid`, depending on interpretation) |
+| `XXXX-XX-XX` | `YYYY-MM-DD` | 3 | `Nonnumeric data` |
+| `0000-04-29` | `YYYY-MM-DD` | 3 | `YearInEra is 0 ` |
+| `2025` | `YYYY-MM-DD` | 3 | `Insufficient   ` |
+| `2025-04-29` | `XXXXXXXXXX` | 3 | `Bad Pic String ` |
+| (empty) | `YYYY-MM-DD` | 3 | `Date is invalid` (`OTHER` branch) |
+
+Note: the exact mapping of Java parse failures to LE feedback codes is a judgment call — `LocalDate.parse` doesn't distinguish "invalid month" from "datevalue error" the same way LE does. The matrix above is the **expected** mapping; if the implementation needs to deviate (e.g. all parse failures collapse to `Date is invalid`), the matrix should be amended in the plan revision before code is written. **This is open decision §8.2 #1.**
+
+### 6.2 Round-trip integration test
+
+```
+For each (date, format) in matrix:
+    java_result = CsutldtcUtil.validate(date, format)
+    cobol_result = exec("./csutldtp", date, format)        # via the oracle binary
+    assert java_result.message80 == cobol_result.bytes
+    assert java_result.severity == cobol_result.severity
+```
+
+### 6.3 Edge-case fixtures
+
+Covered inline by the matrix above; no separate fixture files needed since the inputs are literal strings.
+
+---
+
+## 7. Documents to be produced during implementation
+
+1. Append a "CSUTLDTC — Date Validation Utility" section to
+   `app/java/batch_processing_workflow/README.md`. Note that this is
+   a library, not a runnable batch — it has no `main()`.
+2. Append a CSUTLDTC section to `HOW-TO-TEST.md`, including how to
+   build the CEEDAYS stub.
+3. Add `docs/migration/CSUTLDTC-java-architecture.md` after
+   implementation (very small graph: `CsutldtcUtil → DatePictureParser
+   + LeFeedbackCode → java.time.LocalDate`).
+4. Update `docs/cobol/batch-programs.md` `CSUTLDTC` section pointer.
+5. **Caller migration note** — `CSUTLDTC` is called from
+   `CSUTLDPY` (a copybook glue used by `CORPT00C` and `COTRN02C`).
+   When those callers are eventually migrated, they import
+   `CsutldtcUtil`. Document that in this plan's section 7 so the
+   future caller-migration plans don't re-derive the wrapper.
+
+---
+
+## 8. Risks and open decisions
+
+### 8.1 Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Java's `LocalDate.parse` doesn't surface the same level of detail as LE's feedback tokens → some matrix rows can't be exactly matched | Document the divergences in `HOW-TO-TEST.md`; collapse non-distinguishable cases to `Date is invalid` on the Java side. **Discuss before implementation** (open decision below). |
+| `WS-MESSAGE` byte offsets re-derived from copybook differ by 1 from a careful reading of source — silent diff | Step 4's first unit test asserts exact bytes for one known-good case before any other test runs |
+| GnuCOBOL `CEEDAYS` stub diverges from real LE behaviour | Acceptable. The stub is for the oracle test, not production. Document scope. |
+| COBOL `MOVE` literal-shorter-than-PIC right-pads with space; Java `FixedWidthFormat.writeText` may pad differently | Lock the helper's contract: `writeText(buf, offset, len, src)` MUST right-pad with `0x20` and truncate from the right. Add a test |
+
+### 8.2 Open decisions to confirm
+
+1. **Java→LE feedback mapping** — Java's `DateTimeParseException`
+   message doesn't reliably distinguish `INVALID_MONTH` from
+   `BAD_DATE_VALUE`. Should the Java port preserve that distinction
+   (regex on the exception message, fragile) or collapse all parse
+   errors to `Date is invalid` (simpler, slightly less faithful)?
+   Recommend the collapse; flag if you want exact LE fidelity.
+2. **GnuCOBOL stub coverage** — the `CEEDAYS` stub only needs to
+   handle the matrix in §6.1. If you want coverage of more LE
+   feedback codes, expand the matrix and the stub together.
+3. **Defaults in §3.2** — accept or override.
+4. **Library-only delivery** — `CsutldtcUtil` is a static-method
+   utility; no `main()`. OK?
+
+---
+
+## 9. Out of scope for this migration
+
+- Other LE callable services (`CEEDATM`, `CEELOCT`, etc.).
+- The `CSUTLDPY` copybook glue and its caller programs (`CORPT00C`,
+  `COTRN02C`).
+- Online programs in general.
+- The `COBDATFT` assembler routine — that's covered by the
+  `CBACT01C` plan via `DateConverter`.
+
+---
+
+## 10. Approval gate
+
+Confirm before implementation:
+
+1. **Java→LE feedback mapping policy** — preserve exact LE
+   distinctions (riskier) or collapse parse failures to
+   `Date is invalid` (recommended).
+2. **CEEDAYS stub scope** — minimum-matrix coverage as listed in §6.1.
+3. **Defaults in §3.2** — accept or override.
+4. **Scope locked** to `CSUTLDTC` only — yes/no.
+
+Once confirmed, work proceeds through steps 1–7 in §4.

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,197 @@
+# Batch COBOL → Java Migration Plans
+
+This directory holds one migration plan per COBOL batch program in
+`app/cbl/`. Each plan follows the template established by
+[`CBACT04C-to-java-plan.md`](./CBACT04C-to-java-plan.md) — the first
+program ported and the gold standard for byte-for-byte equivalence
+proven by a portable GnuCOBOL oracle.
+
+The plans assume the foundation laid in
+[`app/java/batch_processing_workflow/`](../../app/java/batch_processing_workflow/)
+(Maven module, Java 17, JUnit 5 + AssertJ, `ZonedDecimalCodec`,
+`FixedWidthFormat`, `Db2Timestamp`, `BatchAbendException`) is reused.
+Each plan calls out the **new** primitives it adds (e.g.
+`PackedDecimalCodec` in `CBACT01C`, `IndexedFileStore` in `CBTRN02C`).
+
+## Status matrix
+
+| # | Program | Plan | Implementation | Driver JCL | Complexity |
+|---|---------|------|----------------|------------|-----------|
+| 1 | `CBACT04C` | [plan](./CBACT04C-to-java-plan.md) · [arch](./CBACT04C-java-architecture.md) | **Done** — `interest/` package, 49 unit tests + golden-file IT | `INTCALC.jcl` | High (5 files, AIX, REWRITE, DB2 timestamp, decimal arithmetic) |
+| 2 | `CBACT01C` | [plan](./CBACT01C-to-java-plan.md) · [arch](./CBACT01C-java-architecture.md) | Plan only | `READACCT.jcl` | Medium (FB+VB outputs, COMP-3, OCCURS, COBDATFT) |
+| 3 | `CBACT02C` | [plan](./CBACT02C-to-java-plan.md) | Pending | `READCARD.jcl` | Low (read+display) |
+| 4 | `CBACT03C` | [plan](./CBACT03C-to-java-plan.md) | Pending | `READXREF.jcl` | Low (read+display) |
+| 5 | `CBCUS01C` | [plan](./CBCUS01C-to-java-plan.md) | Pending | `READCUST.jcl` | Low (read+display) |
+| 6 | `CBTRN01C` | [plan](./CBTRN01C-to-java-plan.md) | Pending | none (orphan) | Low (read+lookup, no writes) |
+| 7 | `CBTRN02C` | [plan](./CBTRN02C-to-java-plan.md) | Pending | `POSTTRAN.jcl` | High (6 files, multiple I-O, validation/rejects, DB2 timestamp) |
+| 8 | `CBTRN03C` | [plan](./CBTRN03C-to-java-plan.md) | Pending | `TRANREPT.jcl` | Medium (paginated FB 133 report, three KSDS lookups) |
+| 9 | `CBSTM03A` + `CBSTM03B` | [plan](./CBSTM03A-CBSTM03B-to-java-plan.md) | Pending | `CREASTMT.JCL` | High (paired; `ALTER … GO TO`; 2D OCCURS table; HTML output) |
+| 10 | `CBEXPORT` + `CBIMPORT` | [plan](./CBEXPORT-CBIMPORT-to-java-plan.md) | Pending | `CBEXPORT.jcl`, `CBIMPORT.jcl` | High (multi-record `REDEFINES`, `COMP` + `COMP-3`) |
+| 11 | `CSUTLDTC` | [plan](./CSUTLDTC-to-java-plan.md) | Pending | none (subroutine) | Low (LE `CEEDAYS` wrapper) |
+
+> "Driver JCL" is the JCL step that runs the program in production.
+> Programs without a driver are subroutines (`CBSTM03B`, `CSUTLDTC`)
+> or scaffolds (`CBTRN01C`).
+
+## Recommended sequencing
+
+The order below maximises foundation reuse and minimises rework. Once
+a phase is complete, the utilities listed under "Promote on completion"
+should be lifted into a shared package
+(`com.carddemo.batch.io` / `.util`) for the next phase.
+
+### Phase 1 — Validate the foundation against simple readers
+
+**Goal.** Prove that the codecs and I/O helpers from `interest/` are
+correct on every read-only program before tackling write paths.
+
+1. **`CBACT02C`** — card master reader. Same template as `CBACT04C`'s
+   open/loop/close skeleton; output is the COBOL `DISPLAY` stream
+   (text). Validates `ZonedDecimalCodec` against `CARDFILE` records and
+   exercises the SYSOUT capture pattern for the first time.
+2. **`CBACT03C`** — xref reader. Identical structure to `CBACT02C`.
+   Adds the 50-byte `CARD-XREF-RECORD` (already known from `CBACT04C`)
+   to the SYSOUT-equivalence harness.
+3. **`CBCUS01C`** — customer master reader. Adds the 500-byte
+   `CUSTOMER-RECORD` layout (`CVCUS01Y`) to the codec test surface.
+4. **`CSUTLDTC`** — date validator. Stand-alone utility; the Java port
+   replaces `CEEDAYS` with `LocalDate.parse()` and pattern-matches LE
+   feedback codes to the same 15-byte severity strings.
+
+**Promote on completion.** `ZonedDecimalCodec`, `FixedWidthFormat`,
+`BatchAbendException` move out of `interest/` into a shared
+`com.carddemo.batch.io` / `.util`. SYSOUT capture helper lands in the
+shared `test-support` source set.
+
+### Phase 2 — Round out the read paths
+
+**Goal.** Cover every shape of input file before adding write paths.
+
+5. **`CBACT01C`** — already planned. Adds `PackedDecimalCodec`
+   (COMP-3) and the `DateConverter` `COBDATFT` replacement. First port
+   to write multiple output files in one run (FB 107, FB 110, two VBR
+   streams).
+6. **`CBTRN01C`** — daily transaction *scaffold* (no writes). First
+   port to use multiple KSDS files in `RANDOM` access with `INVALID
+   KEY` branches. No production load; serves as a low-risk test bed
+   for the random-read store before `CBTRN02C` puts it under load.
+
+**Promote on completion.** `PackedDecimalCodec` joins the shared
+`io` package. A reusable `IndexedFileStore<K, V>` (load → in-memory
+`Map<K, V>` → ABEND on miss) is extracted; this is the abstraction
+both `CBTRN02C` and `CBSTM03B` need.
+
+### Phase 3 — Production write paths
+
+**Goal.** Tackle the programs that update master files.
+
+7. **`CBTRN02C`** — daily transaction poster. Hardest single program
+   in the catalog: 6 files, three of them I-O (`ACCTFILE`, `TCATBALF`,
+   plus the `TRANFILE` `OUTPUT` rewrite), validation flow with reject
+   trailer, DB2 timestamp injection. Reuses `Db2Timestamp` from
+   `interest/`. Sets `RETURN-CODE = 4` on rejects → Java `System.exit(4)`.
+8. **`CBTRN03C`** — transaction detail report. New format territory:
+   FB 133 paginated report with edited PIC clauses (`PIC -ZZZ,ZZZ,ZZZ.ZZ`),
+   page totals every 20 lines via `FUNCTION MOD`, account-break
+   subtotals. The new primitive is `EditedNumericFormat` for COBOL
+   PIC-edit emulation.
+
+**Promote on completion.** `EditedNumericFormat` joins the shared `io`
+package. The reject-record-with-trailer pattern (350 + 80 = 430 bytes)
+is captured in `RejectWriter` if a third caller emerges.
+
+### Phase 4 — Multi-record formats
+
+**Goal.** Handle the export/import pair, then the statement printer.
+
+9. **`CBEXPORT`** + **`CBIMPORT`** — the only programs that use COMP
+   (binary integer) *and* COMP-3 (packed decimal) in the same record,
+   layered with five-way `REDEFINES`. Best done as a pair to share the
+   `EXPORT-RECORD` (500-byte) layout class. Adds `BinaryIntegerCodec`
+   for COMP fields.
+10. **`CBSTM03A`** + **`CBSTM03B`** — paired statement printer. The
+    only program that uses `ALTER … TO PROCEED TO …` + `GO TO` (a
+    self-modifying jump table); the Java port replaces it with a
+    `Map<String, Runnable>` dispatch. Two output formats (FB 80 plain
+    text, FB 100 HTML). Two-dimensional `OCCURS` table maps to
+    `Map<String, List<TrnxRow>>`. `CBSTM03B`'s switch-by-DD-name
+    dispatcher becomes the planned `IndexedFileStore` from Phase 2 but
+    with the operation register (`OPER`) preserved as a façade for
+    byte-for-byte trace equivalence.
+
+**Promote on completion.** `BinaryIntegerCodec` and the
+`MultiRecordReader` discriminator pattern join the shared `io`
+package.
+
+## Cross-cutting work that applies to every plan
+
+The plans share a common shape, summarised here so each plan can stay
+focused on what's *different* about its program:
+
+### Common acceptance criteria
+
+For every program, byte-for-byte equivalence is established by:
+
+1. A **portable GnuCOBOL oracle** (`<PROGRAM>P.cbl` under
+   `cobol-reference/`) that swaps INDEXED VSAM access for `LINE
+   SEQUENTIAL` + in-memory tables, keeping all business logic
+   verbatim.
+2. A `tools/regen-golden.sh` that compiles the oracle (`cobc -x -free
+   -fsign=EBCDIC`), runs it (with `COB_LS_FIXED=Y`), and copies the
+   outputs to `fixtures/expected/`.
+3. A `*GoldenFileEquivalenceIT` integration test that runs the Java
+   port against the same `fixtures/input/` and asserts
+   `Files.mismatch(expected, actual) == -1L` for every output.
+
+The two known sources of divergence neutralised in `CBACT04C` —
+timestamps from `FUNCTION CURRENT-DATE` and JCL `PARM` strings —
+recur in `CBTRN02C` and the export pair. Every plan that hits them
+re-uses `Db2Timestamp.useFixedClock(...)` from `interest/util`.
+
+### Common error-handling translation
+
+Every COBOL program in `app/cbl/` emits the same boilerplate around
+file I/O:
+
+```cobol
+PERFORM 9999-ABEND-PROGRAM        →  throw new BatchAbendException(999)
+PERFORM 9910-DISPLAY-IO-STATUS    →  log("FILE STATUS IS: NNNN<…>")
+APPL-RESULT / APPL-AOK / APPL-EOF →  enum AppResult { OK, EOF, ERROR }
+```
+
+This translation is identical across plans and isn't repeated in each
+plan's section 1.
+
+### Common GnuCOBOL oracle pitfalls
+
+The 14 silent killers from
+[`docs/playbook-cobol-to-java-with-claude.md`](../playbook-cobol-to-java-with-claude.md#common-pitfalls-the-silent-killers)
+apply across every port. The two that bite every COBOL→GnuCOBOL
+oracle are:
+
+- **`-fsign=EBCDIC`** in `cobc` — without it, GnuCOBOL writes plain
+  `0` instead of `{` overpunch on positive zero.
+- **`COB_LS_FIXED=Y`** at run time — without it, `LINE SEQUENTIAL`
+  strips trailing FILLER spaces.
+
+Both are baked into every `tools/build.sh` and `tools/run.sh` template.
+
+## How to use a plan
+
+1. Read the relevant `<PROGRAM>-to-java-plan.md` end-to-end.
+2. Confirm the open decisions in §8 with the project owner.
+3. Work through the steps in §4, one commit per step.
+4. After the golden-file IT passes, write the companion
+   `<PROGRAM>-java-architecture.md` (Mermaid graph) — see
+   [`CBACT04C-java-architecture.md`](./CBACT04C-java-architecture.md)
+   for the template.
+5. Append a one-line pointer to the program's section in
+   [`docs/cobol/batch-programs.md`](../cobol/batch-programs.md).
+
+## Out of scope for this directory
+
+- Online (`CO*`) programs and BMS maps.
+- The three extension modules (`app-transaction-type-db2`,
+  `app-vsam-mq`, `app-authorization-ims-db2-mq`).
+- CICS-driven programs and EXEC SQL host-variable layouts.
+- CI/CD wiring; every plan is local-developer-runnable as written.


### PR DESCRIPTION
Following the template established by docs/migration/CBACT04C-to-java-plan.md
(introduced on branch java-refactory / PR #2), this adds individual
migration plans for the nine remaining COBOL batch programs in app/cbl/
plus an index/roadmap.

- README.md — status matrix + recommended four-phase sequencing that
  maximises foundation reuse
- CBACT02C, CBACT03C, CBCUS01C — simple sequential reader plans
- CBTRN01C — daily-transaction reference reader; introduces shared
  IndexedFileStore<K, V>
- CBTRN02C — production daily transaction poster (most complex single
  program); introduces shared MutableIndexedFileStore<K, V>
- CBTRN03C — paginated FB-133 transaction detail report; introduces
  shared EditedNumericFormat for COBOL PIC-edit emulation
- CBSTM03A-CBSTM03B — paired statement printer; ALTER + GO TO and
  2D OCCURS handled
- CBEXPORT-CBIMPORT — paired multi-record import/export; introduces
  shared BinaryIntegerCodec for COMP integers
- CSUTLDTC — date-validation utility (LE CEEDAYS wrapper)

Each plan follows the CBACT04C/CBACT01C template: source contract,
equivalence requirements, target architecture, step-by-step migration
steps, logic-equivalency safeguards, test strategy, documents to be
produced, risks and open decisions, out of scope, and an approval gate.

The plans assume the foundation laid in app/java/batch_processing_workflow/
on branch java-refactory and identify the new shared utilities each phase
should promote to com.carddemo.batch.io / .util.

https://claude.ai/code/session_01ReNQnChbPzD3xVsbVUmS31